### PR TITLE
Fix #50 - added config

### DIFF
--- a/Artskart3.Api/Program.cs
+++ b/Artskart3.Api/Program.cs
@@ -48,28 +48,9 @@ try
     logger.LogInformation("Services configured successfully");
 
     var app = builder.Build();
-    
-    // Configure the HTTP request pipeline.
-    app.Use(async (context, next) =>
-    {
-        if (context.Request.Path == "/robots.txt")
-        {
-            context.Response.ContentType = "text/plain";
 
-            if (app.Environment.IsDevelopment() || app.Environment.IsEnvironment("Test"))
-            {
-                await context.Response.WriteAsync("User-agent: *\nDisallow: /\n");
-            }
-            else
-            {
-                await context.Response.WriteAsync("User-agent: *\nAllow: /\nCrawl-delay: 1\n");
-            }
-            return;
-        }
+    AddRobotsConfiguration(builder.Configuration, app);
 
-        await next();
-    });
-    
     logger.LogInformation("Building application pipeline...");
 
     app.UseDefaultFiles();
@@ -109,4 +90,34 @@ catch (Exception ex)
     logger.LogCritical("Message: {Message}", ex.Message);
     logger.LogCritical("StackTrace: {StackTrace}", ex.StackTrace);
     throw;
+}
+
+return;
+
+void AddRobotsConfiguration(ConfigurationManager configuration, WebApplication webApplication)
+{
+    // startup config
+    var allowRobotsInProduction = Convert.ToBoolean(configuration["Application:AllowRobotsInProduction"]);
+
+    // Configure the HTTP request pipeline.
+    webApplication.Use(async (context, next) =>
+    {
+        if (context.Request.Path == "/robots.txt")
+        {
+            context.Response.ContentType = "text/plain";
+
+            if (webApplication.Environment.IsDevelopment() || webApplication.Environment.IsEnvironment("Test") || !allowRobotsInProduction)
+            {
+                await context.Response.WriteAsync("User-agent: *\nDisallow: /\n");
+            }
+            else
+            {
+                await context.Response.WriteAsync("User-agent: *\nAllow: /\nCrawl-delay: 1\n");
+            }
+
+            return;
+        }
+
+        await next();
+    });
 }

--- a/Artskart3.Api/appsettings.json
+++ b/Artskart3.Api/appsettings.json
@@ -22,5 +22,8 @@
   },
   "KeyVault": {
     "Url": ""
+  },
+  "Application": {
+    "AllowRobotsInProduction": false
   }
 }

--- a/Artskart3.WebApp/src/proxy.conf.js
+++ b/Artskart3.WebApp/src/proxy.conf.js
@@ -7,6 +7,7 @@ const PROXY_CONFIG = [
   {
     context: [
       "/hc",
+      "/robots.txt"
     ],
     target,
     secure: false


### PR DESCRIPTION
Allow for config on robots for production

Allowing or disabling robots for production is now a config away.

Defaults to disable.

Etter at denne er tatt inn - skal denne ikke lengre svare : https://[adb-prod-artskart3-as.azurewebsites.net/robots.txt](https://adb-prod-artskart3-as.azurewebsites.net/robots.txt)
med 
```
User-agent: *
Allow: /
Crawl-delay: 1
```

men i stedet:
```
User-agent: *
Disallow: /
```