### PR TITLE
#213 add page for testing design system components out of context

### DIFF
--- a/Artskart3.WebApp/src/app/app-module.ts
+++ b/Artskart3.WebApp/src/app/app-module.ts
@@ -8,6 +8,7 @@ import { AppRoutingModule } from './app-routing-module';
 import { App } from './app';
 import { SharedModule } from './shared/shared.module';
 import { LayoutsModule } from './layouts/layouts.module';
+import { DesignComponent } from './shared/components/design.component/design.component';
 import { languageInterceptor } from './shared/interceptors/language.interceptor';
 import { csrfInterceptor } from './shared/interceptors/csrf.interceptor';
 import { LanguageService } from './shared/services/languages/language.service';
@@ -45,6 +46,7 @@ export function initializeLanguageFactory(languageService: LanguageService) {
     AppRoutingModule,
     SharedModule,
     LayoutsModule,
+    DesignComponent,
     TranslateModule.forRoot({
       fallbackLang: 'no',
       loader: {

--- a/Artskart3.WebApp/src/app/app-routing-module.ts
+++ b/Artskart3.WebApp/src/app/app-routing-module.ts
@@ -1,7 +1,12 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
+import { MapComponent } from './shared/components/map.component/map.component';
+import { DesignComponent } from './shared/components/design.component/design.component';
 
-const routes: Routes = [];
+const routes: Routes = [
+  { path: '', component: MapComponent },
+  { path: 'design', component: DesignComponent },
+];
 
 @NgModule({
   imports: [RouterModule.forRoot(routes)],

--- a/Artskart3.WebApp/src/app/app.css
+++ b/Artskart3.WebApp/src/app/app.css
@@ -2,5 +2,5 @@
   width: 100%;
   height: 100vh;
   display: block;
-  overflow: hidden;
+  overflow: clip;
 }

--- a/Artskart3.WebApp/src/app/app.html
+++ b/Artskart3.WebApp/src/app/app.html
@@ -1,4 +1,2 @@
-<app-base-layout>
-  <app-map></app-map>
-</app-base-layout>
+<app-base-layout></app-base-layout>
 

--- a/Artskart3.WebApp/src/app/layouts/base-layout/base-layout.component.css
+++ b/Artskart3.WebApp/src/app/layouts/base-layout/base-layout.component.css
@@ -6,7 +6,9 @@
   align-items: stretch;
   height: 100vh;
   background: var(--adb-background-default);
-  overflow: hidden;
+  overflow: clip;
+  position: fixed;
+  inset: 0;
 }
 
 .layout-container {
@@ -55,21 +57,9 @@
 
 .main-content {
   background: var(--adb-background-default);
-  width: 100%;
+  flex: 1;
   height: 100%;
-}
-
-.content-wrapper {
-  width: 100%;
-  padding: var(--adb-spacing-xl) var(--adb-spacing-lg);
-  min-height: 100%;
-  box-sizing: border-box;
-}
-
-@media (max-width: 1024px) {
-  .content-wrapper {
-    padding: var(--adb-spacing-lg) var(--adb-spacing-md);
-  }
+  overflow: auto;
 }
 
 @media (max-width: 768px) {
@@ -87,10 +77,6 @@
     max-width: var(--panel-max-width);
     z-index: 100;
   }
-
-  .content-wrapper {
-    padding: var(--adb-spacing-md);
-  }
 }
 
 @media (max-width: 480px) {
@@ -100,9 +86,5 @@
 
   .sidebar.open {
     max-width: 100%;
-  }
-
-  .content-wrapper {
-    padding: var(--adb-spacing-md) var(--adb-spacing-xsm);
   }
 }

--- a/Artskart3.WebApp/src/app/layouts/base-layout/base-layout.component.html
+++ b/Artskart3.WebApp/src/app/layouts/base-layout/base-layout.component.html
@@ -25,11 +25,7 @@
     </aside>
 
     <main class="main-content">
-      <ng-content></ng-content>
-
-      <div class="content-wrapper">
-        <router-outlet></router-outlet>
-      </div>
+      <router-outlet></router-outlet>
     </main>
   </div>
 </div>

--- a/Artskart3.WebApp/src/app/shared/components/design.component/design.component.css
+++ b/Artskart3.WebApp/src/app/shared/components/design.component/design.component.css
@@ -1,0 +1,105 @@
+:host {
+  display: block;
+  padding: var(--adb-spacing-xl) var(--adb-spacing-lg);
+  max-width: var(--adb-content-width);
+
+  @media (max-width: 600px) {
+    padding: 0 var(--adb-spacing-xsm) 0 var(--adb-spacing-xsm);
+  }
+}
+
+.design-section {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: var(--adb-spacing-xl);
+  row-gap: var(--adb-spacing-md);
+
+  .link-grid {
+    display: inline-grid;
+    row-gap: 19px;
+    column-gap: 79px;
+    grid-template-rows: repeat(3,fit-content(100%));
+    grid-template-columns: repeat(2,fit-content(100%));
+    
+    a {
+      width: fit-content;
+    }
+
+    a.large {
+        font-size: var(--adb-font-size-6);
+        font-style: normal;
+        font-weight: 400;
+        line-height: 172%;
+    };
+
+    a.medium {
+        font-size: var(--adb-font-size-5);
+        font-style: normal;
+        font-weight: 400;
+        line-height: 172%; 
+    }
+
+    a.small {
+        font-size: var(--adb-font-size-3);
+        font-style: normal;
+        font-weight: 400;
+        line-height: 172%; 
+    }
+  }
+
+  .paragraph {
+    p.large {
+      font-size: var(--adb-font-size-6);
+      font-style: normal;
+      font-weight: 400;
+      /* line-height: 172%; */
+    }
+    
+    p.medium {
+      font-size: var(--adb-font-size-5);
+      font-style: normal;
+      font-weight: 400;
+      /* line-height: 172%; */
+    }
+
+    p.small {
+      font-size: var(--adb-font-size-3);
+      font-style: normal;
+      font-weight: 400;
+    }
+  }
+
+  .horizontal-rule-compact {
+    width: 3.75rem;
+    height: 0.25rem;
+    border-radius: var(--radius-sm, 4px);
+    background: var(--adb-surface-brand-1a, #CF3E1C);
+  }
+
+  .button-grid {
+    display: inline-grid;
+    row-gap: 1.25rem;
+    column-gap: 1rem;
+    grid-template-rows: repeat(3,fit-content(100%));
+    grid-template-columns: repeat(6,fit-content(100%));
+
+    @media (max-width: 768px) {
+      grid-template-rows: repeat(18,fit-content(100%));
+      grid-template-columns: repeat(1,fit-content(100%));
+    }
+  }
+
+  .accordion-wrapper {
+    display: flex;
+    flex-direction: column;
+    row-gap: 1rem;
+    max-width: 32rem;
+  }
+
+  .alert-wrapper {
+    display: flex;
+    flex-direction: column;
+    row-gap: 1rem;
+  }
+}
+

--- a/Artskart3.WebApp/src/app/shared/components/design.component/design.component.html
+++ b/Artskart3.WebApp/src/app/shared/components/design.component/design.component.html
@@ -1,0 +1,234 @@
+<section class="design-section">
+  <div class="headings">
+    <h1>H1 Heading 1</h1>
+    <h2>H2 Heading 2</h2>
+    <h3>H3 Heading 3</h3>
+    <h4>H4 Heading 4</h4>
+    <h5>H5 Heading 5</h5>
+    <h6>H6 Heading 6</h6>
+  </div>
+
+  <div class="link-grid">
+    <a href="" class="adb-link large">Link Large</a><a href="" class="adb-link adb-link--external large">Link external Large</a>
+    <a href="" class="adb-link medium">Link medium</a><a href="" class="adb-link adb-link--external medium">Link external Medium</a>
+    <a href="" class="adb-link">Link normal</a><a href="" class="adb-link adb-link--external">Link external Normal</a>
+    <a href="" class="adb-link small">Link small</a><a href="" class="adb-link adb-link--external small">Link external Small</a>
+  </div>
+
+  <div class="paragraph">
+    <p class="large"><strong>This is a paragraph, large size</strong> - Lorem itsum dolor sit amet. Sed non sagittis leo, ut finibus purus. Nunc condimentum, sapien ut fermentum bibendum, erat velit posuere elit, id vestibulum purus sem id mauris. Praesent in consequat magna. Sed lobortis turpis et leo ornare, nec tincidunt nisl placerat. Nam ullamcorper ex nisl, in convallis ex dapibus eget. Donec tempor feugiat velit sed dignissim. Nulla iaculis egestas orci, eu tempor lorem. Vivamus sit amet tellus neque.</p>
+    <p class="medium"><strong>This is a paragraph, medium size</strong> - Sed non sagittis leo, ut finibus purus. Nunc condimentum, sapien ut fermentum bibendum, erat velit posuere elit, id vestibulum purus sem id mauris. Praesent in consequat magna. Sed lobortis turpis et leo ornare, nec tincidunt nisl placerat. Nam ullamcorper ex nisl, in convallis ex dapibus eget. Donec tempor feugiat velit sed dignissim. Nulla iaculis egestas orci, eu tempor lorem. Vivamus sit amet tellus neque.</p>
+    <p><strong>This is a paragraph, normal size</strong> - Sed non sagittis leo, ut finibus purus. Nunc condimentum, sapien ut fermentum bibendum, erat velit posuere elit, id vestibulum purus sem id mauris. Praesent in consequat magna. Sed lobortis turpis et leo ornare, nec tincidunt nisl placerat. Nam ullamcorper ex nisl, in convallis ex dapibus eget. Donec tempor feugiat velit sed dignissim. Nulla iaculis egestas orci, eu tempor lorem. Vivamus sit amet tellus neque.</p>
+    <p class="small"><strong>This is a paragraph, small size</strong> - Sed non sagittis leo, ut finibus purus. Nunc condimentum, sapien ut fermentum bibendum, erat velit posuere elit, id vestibulum purus sem id mauris. Praesent in consequat magna. Sed lobortis turpis et leo ornare, nec tincidunt nisl placerat. Nam ullamcorper ex nisl, in convallis ex dapibus eget. Donec tempor feugiat velit sed dignissim. Nulla iaculis egestas orci, eu tempor lorem. Vivamus sit amet tellus neque.</p>
+  </div>
+
+  <div class="horizontal-rule-compact"></div>
+  <h2>Komponenter</h2>
+  <h3>Fra det kodede designsystemet</h3>
+  <div>
+    <h3>Avkryssningsboks</h3>
+    <adb-checkbox>Valg</adb-checkbox>
+    <adb-checkbox checked description="Med hjelpetekst">Alternativ</adb-checkbox>
+  </div>
+  <div>
+    <h3>Faner</h3>
+    <adb-tabs>
+      <adb-tab slot="tab">
+        <svg slot="icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
+          <path d="M12.5 17.5L7.5 15.75L3.625 17.25C3.34722 17.3611 3.09028 17.3299 2.85417 17.1563C2.61806 16.9826 2.5 16.75 2.5 16.4583V4.79167C2.5 4.61111 2.55208 4.45139 2.65625 4.3125C2.76042 4.17361 2.90278 4.06944 3.08333 4L7.5 2.5L12.5 4.25L16.375 2.75C16.6528 2.63889 16.9097 2.67014 17.1458 2.84375C17.3819 3.01736 17.5 3.25 17.5 3.54167V15.2083C17.5 15.3889 17.4479 15.5486 17.3438 15.6875C17.2396 15.8264 17.0972 15.9306 16.9167 16L12.5 17.5ZM11.6667 15.4583V5.70833L8.33333 4.54167V14.2917L11.6667 15.4583ZM13.3333 15.4583L15.8333 14.625V4.75L13.3333 5.70833V15.4583ZM4.16667 15.25L6.66667 14.2917V4.54167L4.16667 5.375V15.25Z" fill="currentColor"/>
+        </svg>
+        Kart
+      </adb-tab>
+      <adb-tab slot="tab">
+        <svg slot="icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
+          <path d="M5.83333 7.50004V5.83337H17.5V7.50004H5.83333ZM5.83333 10.8334V9.16671H17.5V10.8334H5.83333ZM5.83333 14.1667V12.5H17.5V14.1667H5.83333ZM3.33333 7.50004C3.09722 7.50004 2.89931 7.42018 2.73958 7.26046C2.57986 7.10074 2.5 6.90282 2.5 6.66671C2.5 6.4306 2.57986 6.23268 2.73958 6.07296C2.89931 5.91324 3.09722 5.83337 3.33333 5.83337C3.56944 5.83337 3.76736 5.91324 3.92708 6.07296C4.08681 6.23268 4.16667 6.4306 4.16667 6.66671C4.16667 6.90282 4.08681 7.10074 3.92708 7.26046C3.76736 7.42018 3.56944 7.50004 3.33333 7.50004ZM3.33333 10.8334C3.09722 10.8334 2.89931 10.7535 2.73958 10.5938C2.57986 10.4341 2.5 10.2362 2.5 10C2.5 9.76393 2.57986 9.56601 2.73958 9.40629C2.89931 9.24657 3.09722 9.16671 3.33333 9.16671C3.56944 9.16671 3.76736 9.24657 3.92708 9.40629C4.08681 9.56601 4.16667 9.76393 4.16667 10C4.16667 10.2362 4.08681 10.4341 3.92708 10.5938C3.76736 10.7535 3.56944 10.8334 3.33333 10.8334ZM3.33333 14.1667C3.09722 14.1667 2.89931 14.0868 2.73958 13.9271C2.57986 13.7674 2.5 13.5695 2.5 13.3334C2.5 13.0973 2.57986 12.8993 2.73958 12.7396C2.89931 12.5799 3.09722 12.5 3.33333 12.5C3.56944 12.5 3.76736 12.5799 3.92708 12.7396C4.08681 12.8993 4.16667 13.0973 4.16667 13.3334C4.16667 13.5695 4.08681 13.7674 3.92708 13.9271C3.76736 14.0868 3.56944 14.1667 3.33333 14.1667Z" fill="currentColor"/>
+        </svg>
+        Liste
+      </adb-tab>
+      <adb-tab slot="tab">
+        <svg slot="icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
+          <path d="M2.49967 15.8333C2.04134 15.8333 1.64898 15.6701 1.32259 15.3437C0.996202 15.0173 0.833008 14.625 0.833008 14.1666V5.83329C0.833008 5.37496 0.996202 4.9826 1.32259 4.65621C1.64898 4.32982 2.04134 4.16663 2.49967 4.16663H10.833C11.2913 4.16663 11.6837 4.32982 12.0101 4.65621C12.3365 4.9826 12.4997 5.37496 12.4997 5.83329V14.1666C12.4997 14.625 12.3365 15.0173 12.0101 15.3437C11.6837 15.6701 11.2913 15.8333 10.833 15.8333H2.49967ZM14.9997 9.16663C14.7636 9.16663 14.5656 9.08677 14.4059 8.92704C14.2462 8.76732 14.1663 8.5694 14.1663 8.33329V4.99996C14.1663 4.76385 14.2462 4.56593 14.4059 4.40621C14.5656 4.24649 14.7636 4.16663 14.9997 4.16663H18.333C18.5691 4.16663 18.767 4.24649 18.9268 4.40621C19.0865 4.56593 19.1663 4.76385 19.1663 4.99996V8.33329C19.1663 8.5694 19.0865 8.76732 18.9268 8.92704C18.767 9.08677 18.5691 9.16663 18.333 9.16663H14.9997ZM15.833 7.49996H17.4997V5.83329H15.833V7.49996ZM2.49967 14.1666H10.833V5.83329H2.49967V14.1666ZM3.33301 12.5H9.99967L7.81217 9.58329L6.24967 11.6666L5.10384 10.1458L3.33301 12.5ZM14.9997 15.8333C14.7636 15.8333 14.5656 15.7534 14.4059 15.5937C14.2462 15.434 14.1663 15.2361 14.1663 15V11.6666C14.1663 11.4305 14.2462 11.2326 14.4059 11.0729C14.5656 10.9132 14.7636 10.8333 14.9997 10.8333H18.333C18.5691 10.8333 18.767 10.9132 18.9268 11.0729C19.0865 11.2326 19.1663 11.4305 19.1663 11.6666V15C19.1663 15.2361 19.0865 15.434 18.9268 15.5937C18.767 15.7534 18.5691 15.8333 18.333 15.8333H14.9997ZM15.833 14.1666H17.4997V12.5H15.833V14.1666Z" fill="currentColor"/>
+        </svg>
+        Galleri
+      </adb-tab>
+      <adb-tab slot="tab">
+        <svg slot="icon" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
+          <path d="M13.333 16.6667V10.8334H16.6663V16.6667H13.333ZM8.33301 16.6667V3.33337H11.6663V16.6667H8.33301ZM3.33301 16.6667V7.50004H6.66634V16.6667H3.33301Z" fill="currentColor"/>
+        </svg>
+        Statistikk
+      </adb-tab>
+      <adb-tab slot="actions"><adb-button variant="secondary" size="sm">Eksporter utvalg</adb-button></adb-tab>
+    </adb-tabs>
+  </div>
+  <div>
+    <h3>Ikonknapp</h3>
+    <adb-icon-button>
+      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+        <path d="M11 13H5V11H11V5H13V11H19V13H13V19H11V13Z" fill="white"/>
+      </svg>
+    </adb-icon-button>
+  </div>
+  <div>
+    <h3>Knapper</h3>
+    <div  class="button-grid">
+      <adb-button variant="primary" size="sm">
+        Primær liten
+      </adb-button>
+      <adb-button variant="primary" size="md">
+        Primær medium
+      </adb-button>
+      <adb-button variant="primary" size="lg">
+        Primær stor
+      </adb-button>
+      <adb-button variant="primary" size="md" disabled>
+        Primær disabled
+      </adb-button>
+      <adb-button variant="primary" size="md" color="danger">
+        Primær danger
+      </adb-button>
+      <adb-button variant="primary" size="md" color="danger" disabled>
+        Primær danger disabled
+      </adb-button>
+      <adb-button variant="secondary" size="sm">
+        Sekundær liten
+      </adb-button>
+      <adb-button variant="secondary" size="md">
+        Sekundær medium
+      </adb-button>
+      <adb-button variant="secondary" size="lg">
+        Sekundær stor
+      </adb-button>
+      <adb-button variant="secondary" size="md" disabled>
+        Sekundær disabled
+      </adb-button>
+      <adb-button variant="secondary" size="md" color="danger">
+        Sekundær danger
+      </adb-button>
+      <adb-button variant="secondary" size="md" color="danger" disabled>
+        Sekundær danger disabled
+      </adb-button>
+      <adb-button variant="tertiary" size="sm">
+        Tertiær liten
+      </adb-button>
+      <adb-button variant="tertiary" size="md">
+        Tertiær medium
+      </adb-button>
+      <adb-button variant="tertiary" size="lg">
+        Tertiær stor
+      </adb-button>
+      <adb-button variant="tertiary" size="md" disabled>
+        Tertiær disabled
+      </adb-button>
+    </div>
+  </div>
+  <div>
+    <h3>Radioknapper</h3>
+    <adb-radio-group label="Velg et alternativ (vertical)">
+      <adb-radio>Alternativ 1</adb-radio>
+      <adb-radio>Alternativ 2</adb-radio>
+    </adb-radio-group>
+    <adb-radio-group label="Velg et alternativ (horizontal)" orientation="horizontal">
+      <adb-radio>Alternativ 1</adb-radio>
+      <adb-radio>Alternativ 2</adb-radio>
+    </adb-radio-group>
+    <adb-radio-group label="Velg et alternativ (disabled)" orientation="horizontal" disabled>
+      <adb-radio>Alternativ 1</adb-radio>
+      <adb-radio>Alternativ 2</adb-radio>
+    </adb-radio-group>
+  </div>
+  <div class="accordion-wrapper">
+    <h3>Trekkspill (Accordion)</h3>
+    <h4>Neutral</h4>
+    <adb-accordion>
+      <adb-accordion-item heading="Artsgrupper">
+        <p>Proin lobortis placerat aliquet. Suspendisse pellentesque blandit neque a bibendum.</p>
+      </adb-accordion-item>
+      <adb-accordion-item heading="Artstre">
+        <p>Fusce mollis nunc eget lectus pharetra rhoncus a placerat lacus.</p>
+      </adb-accordion-item>
+      <adb-accordion-item heading="Rødliste- og fremmedartkategorier">
+        <p>Nunc sollicitudin orci id neque venenatis, at aliquet dolor finibus.</p>
+      </adb-accordion-item>
+      <adb-accordion-item heading="Område">
+        <p>Donec porttitor luctus massa, sed sollicitudin velit fermentum id.</p>
+      </adb-accordion-item>
+      <adb-accordion-item heading="Koordinatpresisjon">
+        <p>Donec justo purus, viverra vitae magna ut, suscipit interdum odio.</p>
+      </adb-accordion-item>
+      <adb-accordion-item heading="Periode">
+        <p>Nam sodales sollicitudin tellus, porta efficitur lacus facilisis sit amet.</p>
+      </adb-accordion-item>
+      <adb-accordion-item heading="Habitat- og Artsegenskaper">
+        <p>Sed vitae feugiat ex. Morbi consequat quam eget tristique lacinia.</p>
+      </adb-accordion-item>
+      <adb-accordion-item heading="Funntype">
+        <p>Quisque risus lacus, sodales vitae molestie a, eleifend eget massa</p>
+      </adb-accordion-item>
+      <adb-accordion-item heading="Institusjoner">
+        <p>Curabitur augue lectus, porta vel interdum in, faucibus sed nunc.</p>
+      </adb-accordion-item>
+      <adb-accordion-item heading="Uker og Måneder">
+        <p>Vivamus non vulputate nunc. Proin rhoncus massa sed turpis efficitur, quis lobortis dolor lacinia.</p>
+      </adb-accordion-item>
+    </adb-accordion>
+    <h4>Subtle</h4>
+    <adb-accordion variant="subtle">
+      <adb-accordion-item heading="Artsgrupper">
+        <p>Proin lobortis placerat aliquet. Suspendisse pellentesque blandit neque a bibendum.</p>
+      </adb-accordion-item>
+      <adb-accordion-item heading="Artstre">
+        <p>Fusce mollis nunc eget lectus pharetra rhoncus a placerat lacus.</p>
+      </adb-accordion-item>
+      <adb-accordion-item heading="Rødliste- og fremmedartkategorier">
+        <p>Nunc sollicitudin orci id neque venenatis, at aliquet dolor finibus.</p>
+      </adb-accordion-item>
+      <adb-accordion-item heading="Område">
+        <p>Donec porttitor luctus massa, sed sollicitudin velit fermentum id.</p>
+      </adb-accordion-item>
+      <adb-accordion-item heading="Koordinatpresisjon">
+        <p>Donec justo purus, viverra vitae magna ut, suscipit interdum odio.</p>
+      </adb-accordion-item>
+      <adb-accordion-item heading="Periode">
+        <p>Nam sodales sollicitudin tellus, porta efficitur lacus facilisis sit amet.</p>
+      </adb-accordion-item>
+      <adb-accordion-item heading="Habitat- og Artsegenskaper">
+        <p>Sed vitae feugiat ex. Morbi consequat quam eget tristique lacinia.</p>
+      </adb-accordion-item>
+      <adb-accordion-item heading="Funntype">
+        <p>Quisque risus lacus, sodales vitae molestie a, eleifend eget massa</p>
+      </adb-accordion-item>
+      <adb-accordion-item heading="Institusjoner">
+        <p>Curabitur augue lectus, porta vel interdum in, faucibus sed nunc.</p>
+      </adb-accordion-item>
+      <adb-accordion-item heading="Uker og Måneder">
+        <p>Vivamus non vulputate nunc. Proin rhoncus massa sed turpis efficitur, quis lobortis dolor lacinia.</p>
+      </adb-accordion-item>
+    </adb-accordion>
+  </div>
+  <div class="alert-wrapper">
+    <h3>Varsel</h3>
+    <adb-alert variant="danger" heading="Fare (danger) global" global>
+      <p>Her kan du legge inn mer informasjon.</p>
+    </adb-alert>
+    <adb-alert variant="danger" heading="Fare (danger)">
+      <p>Her kan du legge inn mer informasjon.</p>
+    </adb-alert>
+    <adb-alert variant="warning" heading="Advarsel (warning)">
+      <p>Her kan du legge inn mer informasjon.</p>
+    </adb-alert>
+    <adb-alert variant="success" closable heading="Suksess (success)" auto-close>
+      <p>Her kan du legge inn mer informasjon.</p>
+    </adb-alert>
+    <adb-alert variant="info" closable heading="Informasjon" auto-close>
+      <span slot="meta">Dato: 30. april 2025</span>
+      <p>Her kan du legge inn mer informasjon.</p>
+    </adb-alert>
+    <adb-alert variant="neutral" closable heading="Nøytral (neutral)" auto-close>
+      <p>Her kan du legge inn mer informasjon.</p>
+    </adb-alert>
+    <adb-alert variant="danger" heading="Fare (danger) inline" type="inline" />
+    <adb-alert variant="warning" heading="Advarsel (warning) inline" type="inline" />
+    <adb-alert variant="success" closable heading="Suksess (success) inline" type="inline" />
+    <adb-alert variant="neutral" closable heading="Nøytral (neutral) inline" type="inline" />
+  </div>
+</section>

--- a/Artskart3.WebApp/src/app/shared/components/design.component/design.component.ts
+++ b/Artskart3.WebApp/src/app/shared/components/design.component/design.component.ts
@@ -1,0 +1,12 @@
+
+import { Component, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+
+
+@Component({
+  selector: 'app-design',
+  standalone: true,
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+  templateUrl: './design.component.html',
+  styleUrl: './design.component.css'
+})
+export class DesignComponent {}

--- a/Artskart3.WebApp/src/app/shared/components/header/header.component.css
+++ b/Artskart3.WebApp/src/app/shared/components/header/header.component.css
@@ -1,3 +1,7 @@
+:host {
+  flex-shrink: 0;
+}
+
 .header {
   display: flex;
   width: 100%;
@@ -42,6 +46,10 @@
   display: flex;
   align-items: center;
   align-self: stretch;
+
+  > a {
+    color: var(--adb-text-primary);
+  }
 }
 
 .logo-icon {

--- a/Artskart3.WebApp/src/app/shared/components/map.component/map.component.css
+++ b/Artskart3.WebApp/src/app/shared/components/map.component/map.component.css
@@ -1,3 +1,8 @@
+:host {
+  display: block;
+  height: 100%;
+  width: 100%;
+}
 
 .map-container {
   position: relative;

--- a/Artskart3.WebApp/src/styles.css
+++ b/Artskart3.WebApp/src/styles.css
@@ -212,7 +212,7 @@ html, body {
     height: 100%;
     margin: 0;
     padding: 0;
-    overflow: hidden;
+    overflow: clip;
 }
 
 app-root {


### PR DESCRIPTION
Page is available at `/design` it should not be linked to within the app. And should probably be removed or excluded from the production build when the app is "released".