### PR TITLE
fix: use Math.floor for zoom normalization to prevent wrong API zoom level

### DIFF
--- a/Artskart3.WebApp/src/app/core/services/validation.service.spec.ts
+++ b/Artskart3.WebApp/src/app/core/services/validation.service.spec.ts
@@ -1,0 +1,44 @@
+import { TestBed } from '@angular/core/testing';
+import { ValidationService } from './validation.service';
+import { ZoomConfig } from '@shared/helpers/zoom/zoom-config';
+
+describe('ValidationService', () => {
+  let service: ValidationService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ValidationService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('validateZoomLevel - API zoom level consistency', () => {
+    it('should produce the same API zoom level before and after normalization', () => {
+      // Fractional zooms near boundaries that previously caused mismatches
+      const edgeCases = [8.5, 8.7, 8.9, 10.5, 10.6, 10.9];
+
+      for (const rawZoom of edgeCases) {
+        const apiLevelFromRaw = ZoomConfig.getApiZoomLevel(rawZoom);
+        const { normalized } = service.validateZoomLevel(rawZoom);
+        const apiLevelFromNormalized = ZoomConfig.getApiZoomLevel(normalized!);
+
+        expect(apiLevelFromNormalized, `Zoom ${rawZoom}: raw gives API level ${apiLevelFromRaw}, but normalized (${normalized}) gives ${apiLevelFromNormalized}`).toBe(apiLevelFromRaw);
+      }
+    });
+
+    it('should floor fractional zoom levels, not round them', () => {
+      expect(service.validateZoomLevel(10.6).normalized).toBe(10);
+      expect(service.validateZoomLevel(10.9).normalized).toBe(10);
+      expect(service.validateZoomLevel(8.5).normalized).toBe(8);
+      expect(service.validateZoomLevel(11.0).normalized).toBe(11);
+    });
+
+    it('should keep integer zoom levels unchanged', () => {
+      expect(service.validateZoomLevel(9).normalized).toBe(9);
+      expect(service.validateZoomLevel(11).normalized).toBe(11);
+      expect(service.validateZoomLevel(5).normalized).toBe(5);
+    });
+  });
+});

--- a/Artskart3.WebApp/src/app/core/services/validation.service.ts
+++ b/Artskart3.WebApp/src/app/core/services/validation.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { ApiMessages, ZoomLevelMapping } from '@core/constants/api-messages';
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class ValidationService {
   validateZoomLevel(zoom: number): { valid: boolean; error?: string; normalized?: number } {
@@ -10,12 +10,12 @@ export class ValidationService {
       return { valid: false, error: ApiMessages.Errors.InvalidParameters };
     }
 
-    const normalized = Math.round(zoom);
+    const normalized = Math.floor(zoom);
 
     if (normalized < ZoomLevelMapping.MIN_ZOOM || normalized > ZoomLevelMapping.MAX_ZOOM) {
       return {
         valid: false,
-        error: `Zoom level must be between ${ZoomLevelMapping.MIN_ZOOM} and ${ZoomLevelMapping.MAX_ZOOM}`
+        error: `Zoom level must be between ${ZoomLevelMapping.MIN_ZOOM} and ${ZoomLevelMapping.MAX_ZOOM}`,
       };
     }
 

--- a/Artskart3.WebApp/src/app/shared/components/map.component/map.component.spec.ts
+++ b/Artskart3.WebApp/src/app/shared/components/map.component/map.component.spec.ts
@@ -1,11 +1,13 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { provideTranslateService } from '@ngx-translate/core';
+import { Subject, throwError, of } from 'rxjs';
 
 import { NbicMapComponent } from '@artsdatabanken/nbic-map-component';
 import { MapComponent } from './map.component';
 import { MapToolbarComponent } from './map-toolbar/map-toolbar.component';
 import { ApiZoomLevel } from './map.types';
+import { AreasService } from '@core/services/areas/areas.service';
 
 describe('MapComponent', () => {
   let component: MapComponent;
@@ -74,6 +76,59 @@ describe('MapComponent', () => {
       applyGeoJsonToLayer(component, ApiZoomLevel.Counties, '{}');
 
       expect(updateGeoJSONLayerSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('setupAreaDataPipeline error resilience', () => {
+    let areasService: AreasService;
+    let updateGeoJSONLayerSpy: ReturnType<typeof vi.fn>;
+    let fetchAreaData$: Subject<{ apiZoomLevel: number; olZoom: number; extent?: [number, number, number, number] }>;
+
+    const accessPrivate = (c: MapComponent) =>
+      c as unknown as {
+        fetchAreaData$: Subject<{ apiZoomLevel: number; olZoom: number; extent?: [number, number, number, number] }>;
+        setupAreaDataPipeline: () => void;
+        geojsonCacheByApiZoom: Map<number, string>;
+      };
+
+    beforeEach(() => {
+      areasService = TestBed.inject(AreasService);
+      updateGeoJSONLayerSpy = vi.fn();
+      component.map = { updateGeoJSONLayer: updateGeoJSONLayerSpy } as unknown as NbicMapComponent;
+
+      const priv = accessPrivate(component);
+      fetchAreaData$ = priv.fetchAreaData$;
+      priv.geojsonCacheByApiZoom.clear();
+      priv.setupAreaDataPipeline();
+    });
+
+    it('should continue processing zoom changes after a service error', () => {
+      vi.useFakeTimers();
+      const geojson = '{"type":"FeatureCollection","features":[]}';
+
+      // First call fails
+      vi.spyOn(areasService, 'getAreaMarkersAsGeoJson').mockReturnValueOnce(
+        throwError(() => new Error('503 Service Unavailable'))
+      );
+
+      fetchAreaData$.next({ apiZoomLevel: ApiZoomLevel.Municipalities, olZoom: 10 });
+      vi.advanceTimersByTime(300);
+
+      expect(updateGeoJSONLayerSpy).not.toHaveBeenCalled();
+
+      // Second call succeeds — pipeline should still be alive
+      vi.spyOn(areasService, 'getLocationsAsGeoJsonString').mockReturnValueOnce(of(geojson));
+
+      fetchAreaData$.next({ apiZoomLevel: ApiZoomLevel.LocationPoints, olZoom: 13 });
+      vi.advanceTimersByTime(300);
+
+      expect(updateGeoJSONLayerSpy).toHaveBeenCalledWith(
+        'area-markers-locations',
+        geojson,
+        { mode: 'replace', dataProjection: 'EPSG:4326' },
+      );
+
+      vi.useRealTimers();
     });
   });
 });

--- a/Artskart3.WebApp/src/app/shared/components/map.component/map.component.ts
+++ b/Artskart3.WebApp/src/app/shared/components/map.component/map.component.ts
@@ -15,8 +15,8 @@ import {
   inject,
 } from '@angular/core';
 import { LoggingService } from '@shared/logging.service';
-import { Subject, Observable } from 'rxjs';
-import { debounceTime, switchMap, takeUntil, tap } from 'rxjs/operators';
+import { Subject, Observable, EMPTY } from 'rxjs';
+import { catchError, debounceTime, switchMap, takeUntil, tap } from 'rxjs/operators';
 import { AreasService } from '@core/services/areas/areas.service';
 import { ZoomConfig } from '@shared/helpers/zoom/zoom-config';
 import { MAP_CONFIG } from '@shared/config/map.config';
@@ -198,16 +198,15 @@ export class MapComponent implements AfterViewInit, OnDestroy {
               this.geojsonCacheByApiZoom.set(apiZoomLevel, geojson);
             }
             this.applyGeoJsonToLayer(apiZoomLevel, geojson);
+          }),
+          catchError((err: unknown) => {
+            this.logger.error(`Failed to load area markers for API zoom level ${apiZoomLevel}:`, 'MapComponent', err);
+            return EMPTY;
           })
         );
       }),
       takeUntil(this.destroy$),
-    ).subscribe({
-      error: (err: unknown) => {
-        this.logger.error('Failed to load area markers:', 'MapComponent', err);
-        this.mapReadyAction.emit(false);
-      },
-    });
+    ).subscribe();
   }
 
   private applyGeoJsonToLayer(apiZoomLevel: number, geojson: string): void {

--- a/Artskart3.WebApp/src/app/shared/components/map.component/map.component.ts
+++ b/Artskart3.WebApp/src/app/shared/components/map.component/map.component.ts
@@ -47,7 +47,7 @@ export class MapComponent implements AfterViewInit, OnDestroy {
   private geojsonCacheByApiZoom = new Map<number, string>();
 
   private destroy$ = new Subject<void>();
-  private fetchAreaData$ = new Subject<{ apiZoomLevel: number; extent?: [number, number, number, number] }>();
+  private fetchAreaData$ = new Subject<{ apiZoomLevel: number; olZoom: number; extent?: [number, number, number, number] }>();
 
   private readonly areasService = inject(AreasService);
   private readonly sharedMapService = inject(SharedMapService);
@@ -156,31 +156,27 @@ export class MapComponent implements AfterViewInit, OnDestroy {
 
     if (apiZoomLevel === ApiZoomLevel.LocationPoints) {
       // For lokasjonspunkter: hent på nytt ved panorering og zoom
-      this.emitFetchEvent();
+      this.emitFetchEvent(zoom);
     } else if (apiZoomLevel !== this.previousApiZoomLevel) {
-      this.emitFetchEvent();
+      this.emitFetchEvent(zoom);
     }
   }
 
-  private emitFetchEvent(): void {
-    const apiZoomLevel = this.getApiZoomLevel();
+  private emitFetchEvent(olZoom?: number): void {
+    const currentZoom = olZoom ?? this.map?.getCamera().zoom ?? ZoomConfig.DEFAULT_ZOOM_LEVEL;
+    const apiZoomLevel = ZoomConfig.getApiZoomLevel(currentZoom);
     const isLocationPoints = apiZoomLevel === ApiZoomLevel.LocationPoints;
     const extent = isLocationPoints
       ? this.map.getExtent() as [number, number, number, number]
       : undefined;
-    this.fetchAreaData$.next({ apiZoomLevel, extent });
-  }
-
-  private getApiZoomLevel(): number {
-    const currentZoom = this.map?.getCamera().zoom ?? ZoomConfig.DEFAULT_ZOOM_LEVEL;
-    return ZoomConfig.getApiZoomLevel(currentZoom);
+    this.fetchAreaData$.next({ apiZoomLevel, olZoom: currentZoom, extent });
   }
 
   private setupAreaDataPipeline(): void {
     this.fetchAreaData$.pipe(
       debounceTime(300),
       tap(({ apiZoomLevel }) => this.previousApiZoomLevel = apiZoomLevel),
-      switchMap(({ apiZoomLevel, extent }) => {
+      switchMap(({ apiZoomLevel, olZoom, extent }) => {
         const isLocationPoints = apiZoomLevel === ApiZoomLevel.LocationPoints;
 
         // Bruk cache for fylker og kommuner, men ikke for lokasjonspunkter (avhenger av kartutsnitt)
@@ -192,10 +188,9 @@ export class MapComponent implements AfterViewInit, OnDestroy {
           }
         }
 
-        const currentZoom = this.map?.getCamera().zoom ?? ZoomConfig.DEFAULT_ZOOM_LEVEL;
         const serviceCall$: Observable<string> = isLocationPoints
           ? this.areasService.getLocationsAsGeoJsonString(extent)
-          : this.areasService.getAreaMarkersAsGeoJson(currentZoom);
+          : this.areasService.getAreaMarkersAsGeoJson(olZoom);
 
         return serviceCall$.pipe(
           tap(geojson => {


### PR DESCRIPTION
fix: use Math.floor for zoom normalization to prevent wrong API zoom level

Math.round caused fractional zooms near thresholds (e.g. 10.6) to round up, producing a different API zoom level than what the map component intended. Also captures OL zoom at event time to avoid a race condition in the area data pipeline.

fix: handle API errors in area data pipeline without killing the stream
 
Move error handling inside switchMap with catchError so a failed request
(e.g. 503) does not terminate the observable chain, allowing subsequent
zoom level changes to still trigger fetches.