### PR TITLE
 fix(list-view): prevent duplicate observation fetch on initial load

### DIFF
--- a/Artskart3.WebApp/src/app/shared/components/list-view/list-view.component.ts
+++ b/Artskart3.WebApp/src/app/shared/components/list-view/list-view.component.ts
@@ -56,8 +56,8 @@ export class ListViewComponent {
   readonly pageSizeOptions = [10, 25, 50];
   readonly resultsPerPage = signal(this.pageSizeOptions[0]);
 
-  readonly observationsResource = rxResource<PagedObservationResponse, ObservationSearchFilter>({
-    params: () => {
+  private readonly searchParams = computed<ObservationSearchFilter>(
+    () => {
       const { countyIds, municipalityIds } = this.areaService.resolvedAreaFilter();
       const coordinatePrecisionFrom = this.filterState.coordinatePrecisionFrom();
       const coordinatePrecisionTo = this.filterState.coordinatePrecisionTo();
@@ -81,6 +81,11 @@ export class ListViewComponent {
         period: hasPeriod ? { from: periodFrom, to: periodTo } : undefined,
       };
     },
+    { equal: (a, b) => JSON.stringify(a) === JSON.stringify(b) },
+  );
+
+  readonly observationsResource = rxResource<PagedObservationResponse, ObservationSearchFilter>({
+    params: () => this.searchParams(),
     stream: ({ params }) => this.observationService.searchObservations(params),
   });
 


### PR DESCRIPTION
 Stabilize rxResource params with a computed signal using structural
 equality (JSON.stringify), so that resolvedAreaFilter recomputing
 from undefined to empty arrays no longer triggers a redundant fetch.