### PR TITLE
Feature/filter i kart

### DIFF
--- a/Artskart3.Api/Controllers/SearchController.cs
+++ b/Artskart3.Api/Controllers/SearchController.cs
@@ -139,7 +139,12 @@ public class SearchController : ControllerBase
     {
         try
         {
-            if (filter != null && !ValidateLocationFilterArraySizes(filter, out var validationError))
+            if (zoomLevel < 1 || zoomLevel > 2)
+            {
+                return BadRequest(new { error = "zoomLevel must be 1 (counties) or 2 (municipalities)." });
+            }
+
+            if (filter != null && !ValidateLocationSearchFilter(filter, out var validationError))
             {
                 return validationError!;
             }

--- a/Artskart3.Api/Controllers/SearchController.cs
+++ b/Artskart3.Api/Controllers/SearchController.cs
@@ -56,9 +56,9 @@ public class SearchController : ControllerBase
     /// Returns aggregated observation counts grouped by location with UTM Zone 33N coordinates.
     /// Defaults to MaxResults = 1000.
     /// </summary>
-    [HttpGet("Locations")]
+    [HttpPost("Locations")]
     [Produces("application/json")]
-    public async Task<ActionResult<string>> GetObservationLocations([FromQuery] LocationSearchFilterDto? filter = null, CancellationToken cancellationToken = default)
+    public async Task<ActionResult<string>> GetObservationLocations([FromBody] LocationSearchFilterDto? filter = null, CancellationToken cancellationToken = default)
     {
         try
         {
@@ -133,9 +133,9 @@ public class SearchController : ControllerBase
     /// Retrieves all area markers (counties and municipalities) with aggregated observation counts and WKT polygons.
     /// When filters are provided, observation counts are computed dynamically.
     /// </summary>
-    [HttpGet("AreaMarkers")]
+    [HttpPost("AreaMarkers")]
     [Produces("application/json")]
-    public async Task<ActionResult<AreaMarkerDto[]>> GetAreaMarkers([FromQuery] int zoomLevel = 1, [FromQuery] LocationSearchFilterDto? filter = null, CancellationToken cancellationToken = default)
+    public async Task<ActionResult<AreaMarkerDto[]>> GetAreaMarkers([FromQuery] int zoomLevel = 1, [FromBody] LocationSearchFilterDto? filter = null, CancellationToken cancellationToken = default)
     {
         try
         {

--- a/Artskart3.Api/Controllers/SearchController.cs
+++ b/Artskart3.Api/Controllers/SearchController.cs
@@ -268,6 +268,44 @@ public class SearchController : ControllerBase
             return false;
         }
 
+        if (!ValidateLocationFilterArraySizes(filter, out validationError))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Validerer at ingen filter-arrayer i lokasjonsfilter overskrider maksimal størrelse.
+    /// </summary>
+    private bool ValidateLocationFilterArraySizes(LocationSearchFilterDto filter, out BadRequestObjectResult? validationError)
+    {
+        validationError = null;
+        var max = SearchConstants.MaxFilterArraySize;
+
+        ReadOnlySpan<(string name, int? length)> arrays =
+        [
+            (nameof(filter.TaxonGroupIds), filter.TaxonGroupIds?.Length),
+            (nameof(filter.CategoryIds), filter.CategoryIds?.Length),
+            (nameof(filter.OrganizationIds), filter.OrganizationIds?.Length),
+            (nameof(filter.MunicipalityIds), filter.MunicipalityIds?.Length),
+            (nameof(filter.CountyIds), filter.CountyIds?.Length),
+            (nameof(filter.RestrictedAreaIds), filter.RestrictedAreaIds?.Length),
+            (nameof(filter.OceanAreaIds), filter.OceanAreaIds?.Length),
+            (nameof(filter.BehaviorIds), filter.BehaviorIds?.Length),
+            (nameof(filter.BasisOfRecordIds), filter.BasisOfRecordIds?.Length),
+        ];
+
+        foreach (var (name, length) in arrays)
+        {
+            if (length > max)
+            {
+                validationError = BadRequest(new { error = $"{name} can contain at most {max} items." });
+                return false;
+            }
+        }
+
         return true;
     }
 

--- a/Artskart3.Api/Controllers/SearchController.cs
+++ b/Artskart3.Api/Controllers/SearchController.cs
@@ -131,14 +131,20 @@ public class SearchController : ControllerBase
 
     /// <summary>
     /// Retrieves all area markers (counties and municipalities) with aggregated observation counts and WKT polygons.
+    /// When filters are provided, observation counts are computed dynamically.
     /// </summary>
     [HttpGet("AreaMarkers")]
     [Produces("application/json")]
-    public async Task<ActionResult<AreaMarkerDto[]>> GetAreaMarkers([FromQuery] int zoomLevel = 1, CancellationToken cancellationToken = default)
+    public async Task<ActionResult<AreaMarkerDto[]>> GetAreaMarkers([FromQuery] int zoomLevel = 1, [FromQuery] LocationSearchFilterDto? filter = null, CancellationToken cancellationToken = default)
     {
         try
         {
-            var areas = await _searchService.GetAreaMarkersAsync(zoomLevel, cancellationToken);
+            if (filter != null && !ValidateLocationFilterArraySizes(filter, out var validationError))
+            {
+                return validationError!;
+            }
+
+            var areas = await _searchService.GetAreaMarkersAsync(zoomLevel, filter, cancellationToken);
             _logger.LogInformation("Retrieved {Count} area markers for zoom level {ZoomLevel}", areas.Count(), zoomLevel);
             return Ok(areas.ToArray());
         }
@@ -256,7 +262,7 @@ public class SearchController : ControllerBase
             return false;
         }
 
-        if (!IsValidCoordinatePrecisionRange(filter.CoordinatePrecisionFrom, filter.CoordinatePrecisionTo))
+        if (filter.CoordinatePrecision?.From != null && filter.CoordinatePrecision?.To != null && !IsValidCoordinatePrecisionRange(filter.CoordinatePrecision.From.Value, filter.CoordinatePrecision.To.Value))
         {
             validationError = BadRequest(new { error = SearchConstants.CoordinatePrecisionInvalidMessage });
             return false;

--- a/Artskart3.Core/Application/DTOs/IObservationFilter.cs
+++ b/Artskart3.Core/Application/DTOs/IObservationFilter.cs
@@ -1,0 +1,20 @@
+namespace Artskart3.Core.Application.DTOs;
+
+/// <summary>
+/// Felles filteregenskaper delt mellom Location- og Observation-søk.
+/// Brukes av ApplyCommonFilters i SearchRepository for å unngå duplisert filterlogikk.
+/// </summary>
+public interface IObservationFilter
+{
+    int[]? TaxonGroupIds { get; }
+    int[]? CategoryIds { get; }
+    int[]? OrganizationIds { get; }
+    string[]? MunicipalityIds { get; }
+    string[]? CountyIds { get; }
+    string[]? RestrictedAreaIds { get; }
+    string[]? OceanAreaIds { get; }
+    int[]? BehaviorIds { get; }
+    int[]? BasisOfRecordIds { get; }
+    CoordinatePrecisionDto? CoordinatePrecision { get; }
+    PeriodDto? Period { get; }
+}

--- a/Artskart3.Core/Application/DTOs/LocationSearchFilterDto.cs
+++ b/Artskart3.Core/Application/DTOs/LocationSearchFilterDto.cs
@@ -1,6 +1,6 @@
 namespace Artskart3.Core.Application.DTOs;
 
-public class LocationSearchFilterDto
+public class LocationSearchFilterDto : IObservationFilter
 {
     public int[]? TaxonGroupIds { get; set; }
 
@@ -43,14 +43,17 @@ public class LocationSearchFilterDto
         Period?.To != null;
 
     /// <summary>
-    /// Returnerer true dersom det finnes filtre som påvirker observasjonsantallet
-    /// (alt utenom rene områdefiltre som bare styrer hvilke områder som vises).
+    /// Returnerer true dersom det finnes filtre som krever dynamisk telling av observasjoner.
+    /// Inkluderer observasjonsattributter (takson, kategori, atferd, etc.) og verneområder
+    /// (som krysser fylkes-/kommunegrenser). Fylker, kommuner og havområder bruker
+    /// pre-beregnede antall og filtrerer kun hvilke områdemarkører som vises.
     /// </summary>
     public bool HasObservationAttributeFilters =>
         TaxonGroupIds?.Length > 0 ||
         CategoryIds?.Length > 0 ||
         BasisOfRecordIds?.Length > 0 ||
         OrganizationIds?.Length > 0 ||
+        RestrictedAreaIds?.Length > 0 ||
         BehaviorIds?.Length > 0 ||
         CoordinatePrecision?.From != null ||
         CoordinatePrecision?.To != null ||

--- a/Artskart3.Core/Application/DTOs/LocationSearchFilterDto.cs
+++ b/Artskart3.Core/Application/DTOs/LocationSearchFilterDto.cs
@@ -4,14 +4,21 @@ public class LocationSearchFilterDto
 {
     public int[]? TaxonGroupIds { get; set; }
 
-    public int[]? Categories { get; set; }
+    public int[]? CategoryIds { get; set; }
 
-    public int[]? BasisOfRecords { get; set; }
+    public int[]? BasisOfRecordIds { get; set; }
 
-    /// <summary>
-    /// Array of CollectionIds (InstitutionCodes) to filter by
-    /// </summary>
-    public string[]? CollectionIds { get; set; }
+    public int[]? OrganizationIds { get; set; }
+
+    public string[]? MunicipalityIds { get; set; }
+
+    public string[]? CountyIds { get; set; }
+
+    public string[]? RestrictedAreaIds { get; set; }
+
+    public string[]? OceanAreaIds { get; set; }
+
+    public int[]? BehaviorIds { get; set; }
 
     /// <summary>
     /// Minimum coordinate precision in meters (0 = no filter)
@@ -22,6 +29,8 @@ public class LocationSearchFilterDto
     /// Maximum coordinate precision in meters (0 = no filter)
     /// </summary>
     public int CoordinatePrecisionTo { get; set; } = 0;
+
+    public PeriodDto? Period { get; set; }
 
     /// <summary>
     /// EPSG code for coordinate system (default: 25833)

--- a/Artskart3.Core/Application/DTOs/LocationSearchFilterDto.cs
+++ b/Artskart3.Core/Application/DTOs/LocationSearchFilterDto.cs
@@ -43,6 +43,21 @@ public class LocationSearchFilterDto
         Period?.To != null;
 
     /// <summary>
+    /// Returnerer true dersom det finnes filtre som påvirker observasjonsantallet
+    /// (alt utenom rene områdefiltre som bare styrer hvilke områder som vises).
+    /// </summary>
+    public bool HasObservationAttributeFilters =>
+        TaxonGroupIds?.Length > 0 ||
+        CategoryIds?.Length > 0 ||
+        BasisOfRecordIds?.Length > 0 ||
+        OrganizationIds?.Length > 0 ||
+        BehaviorIds?.Length > 0 ||
+        CoordinatePrecision?.From != null ||
+        CoordinatePrecision?.To != null ||
+        Period?.From != null ||
+        Period?.To != null;
+
+    /// <summary>
     /// EPSG code for coordinate system (default: 25833)
     /// </summary>
     public int? Epsg { get; set; }

--- a/Artskart3.Core/Application/DTOs/LocationSearchFilterDto.cs
+++ b/Artskart3.Core/Application/DTOs/LocationSearchFilterDto.cs
@@ -20,17 +20,27 @@ public class LocationSearchFilterDto
 
     public int[]? BehaviorIds { get; set; }
 
-    /// <summary>
-    /// Minimum coordinate precision in meters (0 = no filter)
-    /// </summary>
-    public int CoordinatePrecisionFrom { get; set; } = 0;
-
-    /// <summary>
-    /// Maximum coordinate precision in meters (0 = no filter)
-    /// </summary>
-    public int CoordinatePrecisionTo { get; set; } = 0;
+    public CoordinatePrecisionDto? CoordinatePrecision { get; set; }
 
     public PeriodDto? Period { get; set; }
+
+    /// <summary>
+    /// Returnerer true dersom minst ett søkefilter er satt (ekskluderer Envelope, Epsg, MaxResults).
+    /// </summary>
+    public bool HasActiveFilters =>
+        TaxonGroupIds?.Length > 0 ||
+        CategoryIds?.Length > 0 ||
+        BasisOfRecordIds?.Length > 0 ||
+        OrganizationIds?.Length > 0 ||
+        MunicipalityIds?.Length > 0 ||
+        CountyIds?.Length > 0 ||
+        RestrictedAreaIds?.Length > 0 ||
+        OceanAreaIds?.Length > 0 ||
+        BehaviorIds?.Length > 0 ||
+        CoordinatePrecision?.From != null ||
+        CoordinatePrecision?.To != null ||
+        Period?.From != null ||
+        Period?.To != null;
 
     /// <summary>
     /// EPSG code for coordinate system (default: 25833)

--- a/Artskart3.Core/Application/DTOs/ObservationSearchFilterDto.cs
+++ b/Artskart3.Core/Application/DTOs/ObservationSearchFilterDto.cs
@@ -1,6 +1,6 @@
 namespace Artskart3.Core.Application.DTOs;
 
-public class ObservationSearchFilterDto : PaginatedRequestDto
+public class ObservationSearchFilterDto : PaginatedRequestDto, IObservationFilter
 {
     public string? PreferredPopularName { get; set; }
 

--- a/Artskart3.Core/Application/Services/Implementations/SearchService.cs
+++ b/Artskart3.Core/Application/Services/Implementations/SearchService.cs
@@ -49,21 +49,23 @@ public class SearchService : ISearchService
         return alltaxons;
     }
 
-    public async Task<IEnumerable<AreaMarkerDto>> GetAreaMarkersAsync(int zoomLevel, CancellationToken cancellationToken = default)
+    public async Task<IEnumerable<AreaMarkerDto>> GetAreaMarkersAsync(int zoomLevel, LocationSearchFilterDto? filter = null, CancellationToken cancellationToken = default)
     {
-        // Cacher resultater for zoomnivå 1 og 2 (fylker og kommuner)
+        var hasFilters = filter?.HasActiveFilters == true;
+
+        // Cacher kun ufiltrerte resultater for zoomnivå 1 og 2 (fylker og kommuner)
         // da geometridata er store og sjelden endres
-        if (zoomLevel is 1 or 2)
+        if (!hasFilters && zoomLevel is 1 or 2)
         {
             var cacheKey = $"areas_zoom_{zoomLevel}";
             if (!_cache.TryGetValue(cacheKey, out IEnumerable<AreaMarkerDto>? cached))
             {
-                cached = await _searchRepository.GetAreaMarkersAsync(zoomLevel, cancellationToken);
+                cached = await _searchRepository.GetAreaMarkersAsync(zoomLevel, filter, cancellationToken);
                 _cache.Set(cacheKey, cached, AreasCacheDuration);
             }
             return cached!;
         }
 
-        return await _searchRepository.GetAreaMarkersAsync(zoomLevel, cancellationToken);
+        return await _searchRepository.GetAreaMarkersAsync(zoomLevel, filter, cancellationToken);
     }
 }

--- a/Artskart3.Core/Application/Services/Interfaces/IAreaHierarchyService.cs
+++ b/Artskart3.Core/Application/Services/Interfaces/IAreaHierarchyService.cs
@@ -1,0 +1,39 @@
+namespace Artskart3.Core.Application.Services.Interfaces;
+
+/// <summary>
+/// Oppstartslastet oppslag for områdehierarki (kommune→fylke) og Fid→EntityId-konvertering.
+/// Data lastes én gang fra Area-tabellen og holdes i minne.
+/// </summary>
+public interface IAreaHierarchyService
+{
+    /// <summary>
+    /// Returnerer fylkes-Fid for en gitt kommune-Fid, eller null hvis ukjent.
+    /// </summary>
+    string? GetCountyFid(string municipalityFid);
+
+    /// <summary>
+    /// Returnerer alle kommune-Fid-er som tilhører et gitt fylke.
+    /// </summary>
+    IReadOnlyList<string> GetMunicipalityFids(string countyFid);
+
+    /// <summary>
+    /// Konverterer en Fid-streng til EntityId (int) for bruk i ObservationEntityIndex.
+    /// Håndterer historiske fylkes-Fid-er med understrek (f.eks. "15_2017" → 152017).
+    /// </summary>
+    int? FidToEntityId(string fid);
+
+    /// <summary>
+    /// Konverterer en verneområde-Fid til EntityId ved å fjerne "Naturbase VV"-prefiks.
+    /// </summary>
+    int? RestrictedAreaFidToEntityId(string fid);
+
+    /// <summary>
+    /// Batch-konvertering av Fid-er til EntityId-er. Ignorerer ugyldige Fid-er.
+    /// </summary>
+    int[] FidsToEntityIds(string[]? fids);
+
+    /// <summary>
+    /// Batch-konvertering av verneområde-Fid-er til EntityId-er. Ignorerer ugyldige Fid-er.
+    /// </summary>
+    int[] RestrictedAreaFidsToEntityIds(string[]? fids);
+}

--- a/Artskart3.Core/Application/Services/Interfaces/ISearchService.cs
+++ b/Artskart3.Core/Application/Services/Interfaces/ISearchService.cs
@@ -8,5 +8,5 @@ public interface ISearchService
     Task<string> GetLocationsAsync(LocationSearchFilterDto? filter = null, CancellationToken cancellationToken = default);
     Task<List<ObservationDto>> GetObservationsAsync(ObservationSearchFilterDto filter, CancellationToken cancellationToken = default);
 
-    Task<IEnumerable<AreaMarkerDto>> GetAreaMarkersAsync(int zoomLevel, CancellationToken cancellationToken = default);
+    Task<IEnumerable<AreaMarkerDto>> GetAreaMarkersAsync(int zoomLevel, LocationSearchFilterDto? filter = null, CancellationToken cancellationToken = default);
 }

--- a/Artskart3.Core/Domain/RepositoryInterfaces/ISearchRepository.cs
+++ b/Artskart3.Core/Domain/RepositoryInterfaces/ISearchRepository.cs
@@ -8,5 +8,5 @@ public interface ISearchRepository
     Task<IEnumerable<TaxonDto>> GetTaxonsAsync(string name, int maxCount = 20, CancellationToken cancellationToken = default);
     IAsyncEnumerable<LocationModel> GetLocationsAsync(LocationSearchFilterDto? filter = null, CancellationToken cancellationToken = default);
     Task<List<ObservationDto>> GetObservationsAsync(ObservationSearchFilterDto filter, CancellationToken cancellationToken = default);
-    Task<IEnumerable<AreaMarkerDto>> GetAreaMarkersAsync(int zoomLevel, CancellationToken cancellationToken = default);
+    Task<IEnumerable<AreaMarkerDto>> GetAreaMarkersAsync(int zoomLevel, LocationSearchFilterDto? filter = null, CancellationToken cancellationToken = default);
 }

--- a/Artskart3.Infrastructure/Data/DbContext/ArtskartDbContext.cs
+++ b/Artskart3.Infrastructure/Data/DbContext/ArtskartDbContext.cs
@@ -130,6 +130,8 @@ public partial class ArtskartDbContext : DbContext, IArtsKartDbContext
 
             entity.HasIndex(e => e.ParentFid, "IX_ParentFid");
 
+            entity.HasIndex(e => new { e.ZoomLevel, e.IsCurrent }, "IX_Area_ZoomLevel_IsCurrent");
+
             entity.HasIndex(e => e.Name, "NonClusteredIndex-20180305-111522");
 
             entity.Property(e => e.AreaTypeId);
@@ -1019,8 +1021,7 @@ public partial class ArtskartDbContext : DbContext, IArtsKartDbContext
             entity.HasKey(e => new { e.ObservationId, e.EntityTypeId, e.EntityId });
             entity.ToTable("ObservationEntityIndex");
 
-            entity.HasIndex(e => new { e.EntityTypeId, e.EntityId }).HasDatabaseName("IX_ObservationEntityIndex_Lookup");
-            entity.HasIndex(e => e.ObservationId).HasDatabaseName("IX_ObservationEntityIndex_ObservationId");
+            entity.HasIndex(e => new { e.EntityTypeId, e.EntityId, e.ObservationId }).HasDatabaseName("IX_ObservationEntityIndex_EntityType_EntityId_ObsId");
         });
 
         OnModelCreatingPartial(modelBuilder);

--- a/Artskart3.Infrastructure/Data/EntityConfigurations/ObservationSearchIndexConfiguration.cs
+++ b/Artskart3.Infrastructure/Data/EntityConfigurations/ObservationSearchIndexConfiguration.cs
@@ -24,6 +24,7 @@ public class ObservationSearchIndexConfiguration : IEntityTypeConfiguration<Obse
         builder.HasIndex(o => o.InstitutionCode, "IX_Observation_InstitutionCode");
         builder.HasIndex(o => o.YearCollected, "IX_Observation_YearCollected");
         builder.HasIndex(o => o.CoordinatePrecisionInMeters, "IX_Observation_CoordinatePrecisionInMeters");
+        builder.HasIndex(o => o.DateTimeCollected, "IX_Observation_DateTimeCollected");
         builder.HasIndex(o => o.DateLastModified, "IX_Observation_DateLastModified");
 
         // Composite indexes for common filter combinations

--- a/Artskart3.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Artskart3.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using Artskart3.Core.Application.Services.Implementations;
 using Artskart3.Core.Application.Services.Interfaces;
 using Artskart3.Core.Domain.RepositoryInterfaces;
 using Artskart3.Infrastructure.Persistence.Repositories;
+using Artskart3.Infrastructure.Services;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Artskart3.Infrastructure.DependencyInjection;
@@ -19,6 +20,9 @@ public static class ServiceCollectionExtensions
 
     public static IServiceCollection AddApplicationServices(this IServiceCollection services)
     {
+        services.AddSingleton<AreaHierarchyService>();
+        services.AddSingleton<IAreaHierarchyService>(sp => sp.GetRequiredService<AreaHierarchyService>());
+        services.AddHostedService(sp => sp.GetRequiredService<AreaHierarchyService>());
         services.AddScoped<ISearchService, SearchService>();
         services.AddScoped<IUserService, UserService>();
         services.AddScoped<ILookupService, LookupService>();

--- a/Artskart3.Infrastructure/Migrations/20260629093723_ImproveFilterQueryIndexes.Designer.cs
+++ b/Artskart3.Infrastructure/Migrations/20260629093723_ImproveFilterQueryIndexes.Designer.cs
@@ -4,6 +4,7 @@ using Artskart3.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 
@@ -12,9 +13,11 @@ using NetTopologySuite.Geometries;
 namespace Artskart3.Infrastructure.Migrations
 {
     [DbContext(typeof(ArtskartDbContext))]
-    partial class ArtskartDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260629093723_ImproveFilterQueryIndexes")]
+    partial class ImproveFilterQueryIndexes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Artskart3.Infrastructure/Migrations/20260629093723_ImproveFilterQueryIndexes.cs
+++ b/Artskart3.Infrastructure/Migrations/20260629093723_ImproveFilterQueryIndexes.cs
@@ -1,0 +1,69 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Artskart3.Infrastructure.Migrations;
+
+/// <inheritdoc />
+public partial class ImproveFilterQueryIndexes : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        // Erstatter IX_ObservationEntityIndex_Lookup (EntityTypeId, EntityId) — nytt indeks er et superset.
+        migrationBuilder.DropIndex(
+            name: "IX_ObservationEntityIndex_Lookup",
+            table: "ObservationEntityIndex");
+
+        // Erstatter IX_ObservationEntityIndex_ObservationId — PK (ObservationId, EntityTypeId, EntityId) dekker allerede.
+        migrationBuilder.DropIndex(
+            name: "IX_ObservationEntityIndex_ObservationId",
+            table: "ObservationEntityIndex");
+
+        // Covering composite for filtered area/location/observation queries via ObservationEntityIndex.
+        // Erstatter begge fjernede indekser og støtter alle eksisterende spørringsmønstre.
+        migrationBuilder.CreateIndex(
+            name: "IX_ObservationEntityIndex_EntityType_EntityId_ObsId",
+            table: "ObservationEntityIndex",
+            columns: new[] { "EntityTypeId", "EntityId", "ObservationId" });
+
+        // Periodefiltrering (WHERE DateTimeCollected >= @from AND <= @to) mangler indeks.
+        migrationBuilder.CreateIndex(
+            name: "IX_Observation_DateTimeCollected",
+            table: "Observation",
+            column: "DateTimeCollected");
+
+        // GetAreaMarkersAsync filtrerer på (ZoomLevel, IsCurrent) men har ingen indeks.
+        migrationBuilder.CreateIndex(
+            name: "IX_Area_ZoomLevel_IsCurrent",
+            table: "Area",
+            columns: new[] { "ZoomLevel", "IsCurrent" });
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropIndex(
+            name: "IX_ObservationEntityIndex_EntityType_EntityId_ObsId",
+            table: "ObservationEntityIndex");
+
+        migrationBuilder.DropIndex(
+            name: "IX_Observation_DateTimeCollected",
+            table: "Observation");
+
+        migrationBuilder.DropIndex(
+            name: "IX_Area_ZoomLevel_IsCurrent",
+            table: "Area");
+
+        // Gjenopprett de fjernede indeksene
+        migrationBuilder.CreateIndex(
+            name: "IX_ObservationEntityIndex_Lookup",
+            table: "ObservationEntityIndex",
+            columns: new[] { "EntityTypeId", "EntityId" });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_ObservationEntityIndex_ObservationId",
+            table: "ObservationEntityIndex",
+            column: "ObservationId");
+    }
+}

--- a/Artskart3.Infrastructure/Persistence/Repositories/SearchRepository.cs
+++ b/Artskart3.Infrastructure/Persistence/Repositories/SearchRepository.cs
@@ -7,6 +7,7 @@ using Artskart3.Core.Domain.BusinessModels;
 using Artskart3.Core.Domain.Entities;
 using Artskart3.Core.Domain.Enums;
 using Artskart3.Core.Domain.RepositoryInterfaces;
+using Artskart3.Core.Application.Services.Interfaces;
 using Artskart3.Infrastructure.Persistence.Extensions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -21,12 +22,14 @@ public class SearchRepository : ISearchRepository
     private readonly IArtsKartDbContext _context;
     private readonly ILogger<SearchRepository> _logger;
     private readonly PaginationOptions _paginationOptions;
+    private readonly IAreaHierarchyService _areaHierarchy;
 
-    public SearchRepository(IArtsKartDbContext context, ILogger<SearchRepository> logger, IOptions<PaginationOptions> paginationOptions)
+    public SearchRepository(IArtsKartDbContext context, ILogger<SearchRepository> logger, IOptions<PaginationOptions> paginationOptions, IAreaHierarchyService areaHierarchy)
     {
         _context = context ?? throw new ArgumentNullException(nameof(context));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _paginationOptions = paginationOptions.Value;
+        _areaHierarchy = areaHierarchy ?? throw new ArgumentNullException(nameof(areaHierarchy));
     }
     /// <summary>
     /// Searches for taxa by name using a three-level matching strategy:
@@ -180,10 +183,10 @@ public class SearchRepository : ISearchRepository
 
         if (hasMunicipality || hasCounty || hasRestricted || hasOcean || hasOrg)
         {
-            var municipalityIds = ConvertFidsToInt(filter.MunicipalityIds);
-            var countyIds = ConvertFidsToInt(filter.CountyIds);
-            var restrictedIds = ConvertRestrictedAreaFidsToInt(filter.RestrictedAreaIds);
-            var oceanIds = ConvertFidsToInt(filter.OceanAreaIds);
+            var municipalityIds = _areaHierarchy.FidsToEntityIds(filter.MunicipalityIds);
+            var countyIds = _areaHierarchy.FidsToEntityIds(filter.CountyIds);
+            var restrictedIds = _areaHierarchy.RestrictedAreaFidsToEntityIds(filter.RestrictedAreaIds);
+            var oceanIds = _areaHierarchy.FidsToEntityIds(filter.OceanAreaIds);
             var orgIds = filter.OrganizationIds ?? [];
 
             query = query.Where(o => _context.Set<ObservationEntityIndex>().Any(idx =>
@@ -349,10 +352,10 @@ public class SearchRepository : ISearchRepository
 
         if (hasMunicipality || hasCounty || hasRestricted || hasOcean || hasOrg)
         {
-            var municipalityIds = ConvertFidsToInt(filter.MunicipalityIds);
-            var countyIds = ConvertFidsToInt(filter.CountyIds);
-            var restrictedIds = ConvertRestrictedAreaFidsToInt(filter.RestrictedAreaIds);
-            var oceanIds = ConvertFidsToInt(filter.OceanAreaIds);
+            var municipalityIds = _areaHierarchy.FidsToEntityIds(filter.MunicipalityIds);
+            var countyIds = _areaHierarchy.FidsToEntityIds(filter.CountyIds);
+            var restrictedIds = _areaHierarchy.RestrictedAreaFidsToEntityIds(filter.RestrictedAreaIds);
+            var oceanIds = _areaHierarchy.FidsToEntityIds(filter.OceanAreaIds);
             var orgIds = filter.OrganizationIds ?? [];
 
             query = query.Where(o => _context.Set<ObservationEntityIndex>().Any(idx =>
@@ -499,10 +502,37 @@ public class SearchRepository : ISearchRepository
                     .Where(a => a.ZoomLevel == zoomLevel && a.IsCurrent == true)
                     .ToListAsync(cancellationToken);
 
-            var usePrecomputedCounts = filter == null || !filter.HasActiveFilters;
+            var hasFilters = filter?.HasActiveFilters == true;
+            var needsDynamicCounts = hasFilters && filter!.HasObservationAttributeFilters;
             Dictionary<(int entityTypeId, int entityId), int>? dynamicCounts = null;
+            // Aggregerte kommune-antall per fylke (kun for kommune-filter på fylkesnivå)
+            Dictionary<string, int>? municipalityCountsByCounty = null;
 
-            if (!usePrecomputedCounts)
+            if (hasFilters && !needsDynamicCounts)
+            {
+                var filtered = FilterAreasBySelection(areas, filter!);
+                if (filtered.Count > 0)
+                {
+                    var hasMunicipalityFilter = filter!.MunicipalityIds?.Length > 0;
+                    var areasAreCounties = filtered.Any() && !filtered.Any(a => filter.MunicipalityIds?.Contains(a.Fid) == true);
+
+                    if (hasMunicipalityFilter && areasAreCounties)
+                    {
+                        // Kommune-filter på fylkesnivå: summer kommunenes pre-beregnede antall per fylke
+                        municipalityCountsByCounty = await AggregateMunicipalityCountsByCounty(
+                            filter.MunicipalityIds!, cancellationToken);
+                    }
+
+                    areas = filtered;
+                }
+                else
+                {
+                    needsDynamicCounts = true;
+                }
+            }
+
+            // Observasjonsattributtfiltre (eller fallback): beregn antall dynamisk
+            if (needsDynamicCounts)
             {
                 dynamicCounts = await ComputeFilteredAreaCounts(areas, filter!, cancellationToken);
             }
@@ -513,15 +543,25 @@ public class SearchRepository : ISearchRepository
                 {
                     var firstArea = g.FirstOrDefault(a => a.WktPolygon != null) ?? g.First();
 
-                    var count = usePrecomputedCounts
-                        ? g.Sum(a => a.ObservationCount ?? 0)
-                        : g.Sum(a =>
+                    int count;
+                    if (needsDynamicCounts)
+                    {
+                        count = g.Sum(a =>
                         {
-                            var entityId = ConvertSingleFidToInt(a.Fid);
+                            var entityId = _areaHierarchy.FidToEntityId(a.Fid);
                             return entityId.HasValue
                                 ? dynamicCounts!.GetValueOrDefault((a.AreaTypeId, entityId.Value), 0)
                                 : 0;
                         });
+                    }
+                    else if (municipalityCountsByCounty != null)
+                    {
+                        count = g.Sum(a => municipalityCountsByCounty.GetValueOrDefault(a.Fid, 0));
+                    }
+                    else
+                    {
+                        count = g.Sum(a => a.ObservationCount ?? 0);
+                    }
 
                     return new AreaMarkerDto
                     {
@@ -538,6 +578,7 @@ public class SearchRepository : ISearchRepository
                             : null
                     };
                 })
+                .Where(a => a.ObservationCount > 0)
                 .ToList();
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
@@ -546,6 +587,34 @@ public class SearchRepository : ISearchRepository
             throw new ApplicationException(
                 "An error occurred while retrieving areas. Please try again later.", ex);
         }
+    }
+
+    /// <summary>
+    /// Henter pre-beregnede observasjonsantall for valgte kommuner og aggregerer per forelder-fylke.
+    /// Brukes når kommune-filter er aktivt på fylkesnivå — unngår tung observasjonstelling.
+    /// </summary>
+    private async Task<Dictionary<string, int>> AggregateMunicipalityCountsByCounty(
+        string[] municipalityFids, CancellationToken cancellationToken)
+    {
+        var fidsSet = municipalityFids.ToHashSet();
+
+        var municipalityAreas = await _context.Set<Area>()
+            .Where(a => a.IsCurrent && fidsSet.Contains(a.Fid))
+            .Select(a => new { a.Fid, a.ParentFid, a.ObservationCount })
+            .ToListAsync(cancellationToken);
+
+        var countsByCounty = new Dictionary<string, int>();
+
+        foreach (var m in municipalityAreas)
+        {
+            var countyFid = m.ParentFid ?? _areaHierarchy.GetCountyFid(m.Fid);
+            if (countyFid == null) continue;
+
+            countsByCounty.TryGetValue(countyFid, out var current);
+            countsByCounty[countyFid] = current + (m.ObservationCount ?? 0);
+        }
+
+        return countsByCounty;
     }
 
     /// <summary>
@@ -558,7 +627,7 @@ public class SearchRepository : ISearchRepository
 
         var entityTypeIds = areas.Select(a => a.AreaTypeId).Distinct().ToArray();
         var entityIds = areas
-            .Select(a => ConvertSingleFidToInt(a.Fid))
+            .Select(a => _areaHierarchy.FidToEntityId(a.Fid))
             .Where(id => id.HasValue)
             .Select(id => id!.Value)
             .Distinct()
@@ -574,34 +643,33 @@ public class SearchRepository : ISearchRepository
         return counts.ToDictionary(x => (x.EntityTypeId, x.EntityId), x => x.Count);
     }
 
-    private static int? ConvertSingleFidToInt(string fid)
+    /// <summary>
+    /// Filtrerer områdelisten basert på valgte fylker/kommuner.
+    /// Bruker AreaHierarchyService for å slå opp forelder-fylke fra kommune-Fid.
+    /// </summary>
+    private List<Area> FilterAreasBySelection(List<Area> areas, LocationSearchFilterDto filter)
     {
-        return int.TryParse(fid.Replace("_", ""), out var id) ? id : (int?)null;
+        var countyFids = new HashSet<string>(filter.CountyIds ?? []);
+        var municipalityFids = new HashSet<string>(filter.MunicipalityIds ?? []);
+
+        if (countyFids.Count == 0 && municipalityFids.Count == 0)
+            return areas;
+
+        // Slå opp forelder-fylke for valgte kommuner
+        var derivedCountyFids = new HashSet<string>();
+        foreach (var mFid in municipalityFids)
+        {
+            var parentCounty = _areaHierarchy.GetCountyFid(mFid);
+            if (parentCounty != null)
+                derivedCountyFids.Add(parentCounty);
+        }
+
+        return areas.Where(a =>
+            countyFids.Contains(a.Fid) ||
+            municipalityFids.Contains(a.Fid) ||
+            countyFids.Contains(a.ParentFid) ||
+            derivedCountyFids.Contains(a.Fid)
+        ).ToList();
     }
 
-    /// <summary>
-    /// Konverterer string-Fid-er til int ved å fjerne "_" (for historiske fylkes-Fid-er som "15_2017").
-    /// </summary>
-    private static int[] ConvertFidsToInt(string[]? fids)
-    {
-        if (fids == null || fids.Length == 0) return [];
-        return fids
-            .Select(fid => int.TryParse(fid.Replace("_", ""), out var id) ? id : (int?)null)
-            .Where(id => id.HasValue)
-            .Select(id => id!.Value)
-            .ToArray();
-    }
-
-    /// <summary>
-    /// Konverterer verneområde-Fid-er til int ved å fjerne "Naturbase VV"-prefiks.
-    /// </summary>
-    private static int[] ConvertRestrictedAreaFidsToInt(string[]? fids)
-    {
-        if (fids == null || fids.Length == 0) return [];
-        return fids
-            .Select(fid => int.TryParse(fid.Replace("Naturbase VV", ""), out var id) ? id : (int?)null)
-            .Where(id => id.HasValue)
-            .Select(id => id!.Value)
-            .ToArray();
-    }
 }

--- a/Artskart3.Infrastructure/Persistence/Repositories/SearchRepository.cs
+++ b/Artskart3.Infrastructure/Persistence/Repositories/SearchRepository.cs
@@ -332,22 +332,46 @@ public class SearchRepository : ISearchRepository
             query = query.Where(o => taxonGroupIds.Contains(o.TaxonGroupId));
         }
 
-        if (filter.CollectionIds?.Any() == true)
+        if (filter.CategoryIds?.Any() == true)
         {
-            var collectionIds = filter.CollectionIds.ToList();
-            query = query.Where(o => o.InstitutionCode != null && collectionIds.Contains(o.InstitutionCode));
+            var categoryIds = filter.CategoryIds.ToList();
+            query = query.Where(o => o.CategoryId.HasValue && categoryIds.Contains(o.CategoryId.Value));
         }
 
-        if (filter.Categories?.Any() == true)
+        // Område- og organisasjonsfiltre via ObservationEntityIndex-tabellen (same mønster som observasjoner)
+        var hasMunicipality = filter.MunicipalityIds?.Any() == true;
+        var hasCounty = filter.CountyIds?.Any() == true;
+        var hasRestricted = filter.RestrictedAreaIds?.Any() == true;
+        var hasOcean = filter.OceanAreaIds?.Any() == true;
+        var hasOrg = filter.OrganizationIds?.Any() == true;
+
+        if (hasMunicipality || hasCounty || hasRestricted || hasOcean || hasOrg)
         {
-            var categories = filter.Categories.ToList();
-            query = query.Where(o => o.CategoryId.HasValue && categories.Contains(o.CategoryId.Value));
+            var municipalityIds = ConvertFidsToInt(filter.MunicipalityIds);
+            var countyIds = ConvertFidsToInt(filter.CountyIds);
+            var restrictedIds = ConvertRestrictedAreaFidsToInt(filter.RestrictedAreaIds);
+            var oceanIds = ConvertFidsToInt(filter.OceanAreaIds);
+            var orgIds = filter.OrganizationIds ?? [];
+
+            query = query.Where(o => _context.Set<ObservationEntityIndex>().Any(idx =>
+                idx.ObservationId == o.Id && (
+                    (idx.EntityTypeId == (int)ObservationIndexEntityType.Municipality && municipalityIds.Contains(idx.EntityId)) ||
+                    (idx.EntityTypeId == (int)ObservationIndexEntityType.County && countyIds.Contains(idx.EntityId)) ||
+                    (idx.EntityTypeId == (int)ObservationIndexEntityType.RestrictedArea && restrictedIds.Contains(idx.EntityId)) ||
+                    (idx.EntityTypeId == (int)ObservationIndexEntityType.OceanArea && oceanIds.Contains(idx.EntityId)) ||
+                    (idx.EntityTypeId == (int)ObservationIndexEntityType.Institution && orgIds.Contains(idx.EntityId))
+                )));
         }
 
-        if (filter.BasisOfRecords?.Any() == true)
+        if (filter.BehaviorIds?.Any() == true)
         {
-            var basisOfRecords = filter.BasisOfRecords.ToList();
-            query = query.Where(o => basisOfRecords.Contains(o.BasisOfRecordId));
+            query = query.Where(o => o.Behaviors.Any(b => filter.BehaviorIds.Contains(b.Id)));
+        }
+
+        if (filter.BasisOfRecordIds?.Any() == true)
+        {
+            var basisOfRecordIds = filter.BasisOfRecordIds.ToList();
+            query = query.Where(o => basisOfRecordIds.Contains(o.BasisOfRecordId));
         }
 
         if (filter.CoordinatePrecisionFrom > 0)
@@ -358,6 +382,18 @@ public class SearchRepository : ISearchRepository
         if (filter.CoordinatePrecisionTo > 0)
         {
             query = query.Where(o => o.CoordinatePrecisionInMeters <= filter.CoordinatePrecisionTo);
+        }
+
+        if (filter.Period?.From.HasValue == true)
+        {
+            var fromDate = new DateTime(filter.Period.From.Value, 1, 1);
+            query = query.Where(o => o.DateTimeCollected >= fromDate);
+        }
+
+        if (filter.Period?.To.HasValue == true)
+        {
+            var toDate = new DateTime(filter.Period.To.Value, 12, 31, 23, 59, 59);
+            query = query.Where(o => o.DateTimeCollected <= toDate);
         }
 
         if (filter.Envelope != null)

--- a/Artskart3.Infrastructure/Persistence/Repositories/SearchRepository.cs
+++ b/Artskart3.Infrastructure/Persistence/Repositories/SearchRepository.cs
@@ -279,29 +279,36 @@ public class SearchRepository : ISearchRepository
             query = query.Where(o => o.CategoryId.HasValue && categoryIds.Contains(o.CategoryId.Value));
         }
 
-        // Område- og organisasjonsfiltre via ObservationEntityIndex-tabellen
+        // Geografiske områdefiltre via ObservationEntityIndex (OR — observasjon i minst ett av områdene)
         var hasMunicipality = filter.MunicipalityIds?.Any() == true;
         var hasCounty = filter.CountyIds?.Any() == true;
         var hasRestricted = filter.RestrictedAreaIds?.Any() == true;
         var hasOcean = filter.OceanAreaIds?.Any() == true;
-        var hasOrg = filter.OrganizationIds?.Any() == true;
 
-        if (hasMunicipality || hasCounty || hasRestricted || hasOcean || hasOrg)
+        if (hasMunicipality || hasCounty || hasRestricted || hasOcean)
         {
             var municipalityIds = _areaHierarchy.FidsToEntityIds(filter.MunicipalityIds);
             var countyIds = _areaHierarchy.FidsToEntityIds(filter.CountyIds);
             var restrictedIds = _areaHierarchy.RestrictedAreaFidsToEntityIds(filter.RestrictedAreaIds);
             var oceanIds = _areaHierarchy.FidsToEntityIds(filter.OceanAreaIds);
-            var orgIds = filter.OrganizationIds ?? [];
 
             query = query.Where(o => _context.Set<ObservationEntityIndex>().Any(idx =>
                 idx.ObservationId == o.Id && (
                     (idx.EntityTypeId == (int)ObservationIndexEntityType.Municipality && municipalityIds.Contains(idx.EntityId)) ||
                     (idx.EntityTypeId == (int)ObservationIndexEntityType.County && countyIds.Contains(idx.EntityId)) ||
                     (idx.EntityTypeId == (int)ObservationIndexEntityType.RestrictedArea && restrictedIds.Contains(idx.EntityId)) ||
-                    (idx.EntityTypeId == (int)ObservationIndexEntityType.OceanArea && oceanIds.Contains(idx.EntityId)) ||
-                    (idx.EntityTypeId == (int)ObservationIndexEntityType.Institution && orgIds.Contains(idx.EntityId))
+                    (idx.EntityTypeId == (int)ObservationIndexEntityType.OceanArea && oceanIds.Contains(idx.EntityId))
                 )));
+        }
+
+        // Organisasjonsfilter (AND — separat fra geografiske filtre)
+        if (filter.OrganizationIds?.Any() == true)
+        {
+            var orgIds = filter.OrganizationIds;
+            query = query.Where(o => _context.Set<ObservationEntityIndex>().Any(idx =>
+                idx.ObservationId == o.Id &&
+                idx.EntityTypeId == (int)ObservationIndexEntityType.Institution &&
+                orgIds.Contains(idx.EntityId)));
         }
 
         if (filter.BehaviorIds?.Any() == true)

--- a/Artskart3.Infrastructure/Persistence/Repositories/SearchRepository.cs
+++ b/Artskart3.Infrastructure/Persistence/Repositories/SearchRepository.cs
@@ -145,6 +145,7 @@ public class SearchRepository : ISearchRepository
         var query = _context.Set<Observation>()
                             .AsNoTracking();
 
+        // Observasjonsspesifikke tekstfiltre
         if (!string.IsNullOrEmpty(filter.PreferredPopularName))
         {
             var popularNamePattern = SqlWildcard + filter.PreferredPopularName.EscapeSqlLikePattern() + SqlWildcard;
@@ -163,73 +164,8 @@ public class SearchRepository : ISearchRepository
             query = query.Where(o => EF.Functions.Like(o.MatchedScientificName.ScientificNameAuthorship, authorPattern));
         }
 
-        if (filter.TaxonGroupIds?.Any() == true)
-        {
-            query = query.Where(o => filter.TaxonGroupIds.Contains(o.TaxonGroupId));
-        }
-
-        if (filter.CategoryIds?.Any() == true)
-        {
-            query = query.Where(o => o.CategoryId != null && filter.CategoryIds.Contains(o.CategoryId.Value));
-        }
-
-        // Område- og organisasjonsfiltre via ObservationEntityIndex-tabellen.
-        // Alle entiteter bruker int EntityId — string-Fid-er konverteres til int før spørring.
-        var hasMunicipality = filter.MunicipalityIds?.Any() == true;
-        var hasCounty = filter.CountyIds?.Any() == true;
-        var hasRestricted = filter.RestrictedAreaIds?.Any() == true;
-        var hasOcean = filter.OceanAreaIds?.Any() == true;
-        var hasOrg = filter.OrganizationIds?.Any() == true;
-
-        if (hasMunicipality || hasCounty || hasRestricted || hasOcean || hasOrg)
-        {
-            var municipalityIds = _areaHierarchy.FidsToEntityIds(filter.MunicipalityIds);
-            var countyIds = _areaHierarchy.FidsToEntityIds(filter.CountyIds);
-            var restrictedIds = _areaHierarchy.RestrictedAreaFidsToEntityIds(filter.RestrictedAreaIds);
-            var oceanIds = _areaHierarchy.FidsToEntityIds(filter.OceanAreaIds);
-            var orgIds = filter.OrganizationIds ?? [];
-
-            query = query.Where(o => _context.Set<ObservationEntityIndex>().Any(idx =>
-                idx.ObservationId == o.Id && (
-                    (idx.EntityTypeId == (int)ObservationIndexEntityType.Municipality && municipalityIds.Contains(idx.EntityId)) ||
-                    (idx.EntityTypeId == (int)ObservationIndexEntityType.County && countyIds.Contains(idx.EntityId)) ||
-                    (idx.EntityTypeId == (int)ObservationIndexEntityType.RestrictedArea && restrictedIds.Contains(idx.EntityId)) ||
-                    (idx.EntityTypeId == (int)ObservationIndexEntityType.OceanArea && oceanIds.Contains(idx.EntityId)) ||
-                    (idx.EntityTypeId == (int)ObservationIndexEntityType.Institution && orgIds.Contains(idx.EntityId))
-                )));
-        }
-
-        if (filter.BehaviorIds?.Any() == true)
-        {
-            query = query.Where(o => o.Behaviors.Any(b => filter.BehaviorIds.Contains(b.Id)));
-        }
-
-        if (filter.BasisOfRecordIds?.Any() == true)
-        {
-            query = query.Where(o => filter.BasisOfRecordIds.Contains(o.BasisOfRecordId));
-        }
-
-        if (filter.CoordinatePrecision?.From.HasValue == true)
-        {
-            query = query.Where(o => o.CoordinatePrecisionInMeters >= filter.CoordinatePrecision.From.Value);
-        }
-
-        if (filter.CoordinatePrecision?.To.HasValue == true)
-        {
-            query = query.Where(o => o.CoordinatePrecisionInMeters <= filter.CoordinatePrecision.To.Value);
-        }
-
-        if (filter.Period?.From.HasValue == true)
-        {
-            var fromDate = new DateTime(filter.Period.From.Value, 1, 1);
-            query = query.Where(o => o.DateTimeCollected >= fromDate);
-        }
-
-        if (filter.Period?.To.HasValue == true)
-        {
-            var toDate = new DateTime(filter.Period.To.Value, 12, 31, 23, 59, 59);
-            query = query.Where(o => o.DateTimeCollected <= toDate);
-        }
+        // Felles filtre (taksongruppe, kategori, område, atferd, presisjon, periode)
+        query = ApplyCommonFilters(query, filter);
 
         query = query.OrderBy(o => o.Id);
 
@@ -329,7 +265,7 @@ public class SearchRepository : ISearchRepository
     /// Legger til felles filterpredikater (taksongruppe, kategori, område, atferd, etc.) på en observasjonsspørring.
     /// Brukes av både lokasjons- og områdemarkørspørringer.
     /// </summary>
-    private IQueryable<Observation> ApplyCommonFilters(IQueryable<Observation> query, LocationSearchFilterDto filter)
+    private IQueryable<Observation> ApplyCommonFilters(IQueryable<Observation> query, IObservationFilter filter)
     {
         if (filter.TaxonGroupIds?.Any() == true)
         {
@@ -502,6 +438,20 @@ public class SearchRepository : ISearchRepository
                     .Where(a => a.ZoomLevel == zoomLevel && a.IsCurrent == true)
                     .ToListAsync(cancellationToken);
 
+            // Havområder kan ha et annet zoomnivå — last inn separat når de er i filteret
+            if (filter?.OceanAreaIds?.Any() == true)
+            {
+                var loadedFids = areas.Select(a => a.Fid).ToHashSet();
+                var missingOceanFids = filter.OceanAreaIds.Where(fid => !loadedFids.Contains(fid)).ToArray();
+                if (missingOceanFids.Length > 0)
+                {
+                    var oceanAreas = await _context.Set<Area>()
+                        .Where(a => a.IsCurrent && missingOceanFids.Contains(a.Fid))
+                        .ToListAsync(cancellationToken);
+                    areas.AddRange(oceanAreas);
+                }
+            }
+
             var hasFilters = filter?.HasActiveFilters == true;
             var needsDynamicCounts = hasFilters && filter!.HasObservationAttributeFilters;
             Dictionary<(int entityTypeId, int entityId), int>? dynamicCounts = null;
@@ -525,9 +475,16 @@ public class SearchRepository : ISearchRepository
 
                     areas = filtered;
                 }
+                else if (filter!.HasObservationAttributeFilters)
+                {
+                    // Områdefiltre matcher ikke på dette zoomnivået, men observasjonsfiltre
+                    // kan endre tellingen — fall tilbake til dynamisk telling.
+                    needsDynamicCounts = true;
+                }
                 else
                 {
-                    needsDynamicCounts = true;
+                    // Kun områdefiltre, men ingen matcher dette zoomnivået — ingen markører å vise.
+                    areas = filtered;
                 }
             }
 
@@ -644,15 +601,17 @@ public class SearchRepository : ISearchRepository
     }
 
     /// <summary>
-    /// Filtrerer områdelisten basert på valgte fylker/kommuner.
+    /// Filtrerer områdelisten basert på valgte fylker, kommuner og havområder.
+    /// Alle er områdemarkører på samme nivå og filtreres via Fid-matching.
     /// Bruker AreaHierarchyService for å slå opp forelder-fylke fra kommune-Fid.
     /// </summary>
     private List<Area> FilterAreasBySelection(List<Area> areas, LocationSearchFilterDto filter)
     {
         var countyFids = new HashSet<string>(filter.CountyIds ?? []);
         var municipalityFids = new HashSet<string>(filter.MunicipalityIds ?? []);
+        var oceanAreaFids = new HashSet<string>(filter.OceanAreaIds ?? []);
 
-        if (countyFids.Count == 0 && municipalityFids.Count == 0)
+        if (countyFids.Count == 0 && municipalityFids.Count == 0 && oceanAreaFids.Count == 0)
             return areas;
 
         // Slå opp forelder-fylke for valgte kommuner
@@ -667,7 +626,8 @@ public class SearchRepository : ISearchRepository
         return areas.Where(a =>
             countyFids.Contains(a.Fid) ||
             municipalityFids.Contains(a.Fid) ||
-            countyFids.Contains(a.ParentFid) ||
+            oceanAreaFids.Contains(a.Fid) ||
+            (a.ParentFid != null && countyFids.Contains(a.ParentFid)) ||
             derivedCountyFids.Contains(a.Fid)
         ).ToList();
     }

--- a/Artskart3.Infrastructure/Persistence/Repositories/SearchRepository.cs
+++ b/Artskart3.Infrastructure/Persistence/Repositories/SearchRepository.cs
@@ -322,10 +322,12 @@ public class SearchRepository : ISearchRepository
         }
     }
 
-    private IQueryable<Observation> BuildLocationsQuery(LocationSearchFilterDto filter)
+    /// <summary>
+    /// Legger til felles filterpredikater (taksongruppe, kategori, område, atferd, etc.) på en observasjonsspørring.
+    /// Brukes av både lokasjons- og områdemarkørspørringer.
+    /// </summary>
+    private IQueryable<Observation> ApplyCommonFilters(IQueryable<Observation> query, LocationSearchFilterDto filter)
     {
-        var query = _context.Set<Observation>().AsNoTracking();
-
         if (filter.TaxonGroupIds?.Any() == true)
         {
             var taxonGroupIds = filter.TaxonGroupIds.ToList();
@@ -338,7 +340,7 @@ public class SearchRepository : ISearchRepository
             query = query.Where(o => o.CategoryId.HasValue && categoryIds.Contains(o.CategoryId.Value));
         }
 
-        // Område- og organisasjonsfiltre via ObservationEntityIndex-tabellen (same mønster som observasjoner)
+        // Område- og organisasjonsfiltre via ObservationEntityIndex-tabellen
         var hasMunicipality = filter.MunicipalityIds?.Any() == true;
         var hasCounty = filter.CountyIds?.Any() == true;
         var hasRestricted = filter.RestrictedAreaIds?.Any() == true;
@@ -374,14 +376,14 @@ public class SearchRepository : ISearchRepository
             query = query.Where(o => basisOfRecordIds.Contains(o.BasisOfRecordId));
         }
 
-        if (filter.CoordinatePrecisionFrom > 0)
+        if (filter.CoordinatePrecision?.From.HasValue == true)
         {
-            query = query.Where(o => o.CoordinatePrecisionInMeters >= filter.CoordinatePrecisionFrom);
+            query = query.Where(o => o.CoordinatePrecisionInMeters >= filter.CoordinatePrecision.From.Value);
         }
 
-        if (filter.CoordinatePrecisionTo > 0)
+        if (filter.CoordinatePrecision?.To.HasValue == true)
         {
-            query = query.Where(o => o.CoordinatePrecisionInMeters <= filter.CoordinatePrecisionTo);
+            query = query.Where(o => o.CoordinatePrecisionInMeters <= filter.CoordinatePrecision.To.Value);
         }
 
         if (filter.Period?.From.HasValue == true)
@@ -395,6 +397,14 @@ public class SearchRepository : ISearchRepository
             var toDate = new DateTime(filter.Period.To.Value, 12, 31, 23, 59, 59);
             query = query.Where(o => o.DateTimeCollected <= toDate);
         }
+
+        return query;
+    }
+
+    private IQueryable<Observation> BuildLocationsQuery(LocationSearchFilterDto filter)
+    {
+        var query = _context.Set<Observation>().AsNoTracking();
+        query = ApplyCommonFilters(query, filter);
 
         if (filter.Envelope != null)
         {
@@ -477,12 +487,11 @@ public class SearchRepository : ISearchRepository
     }
 
     /// <summary>
-    /// Retrieves all area markers (counties/municipalities) grouped by name with aggregated observation counts.
-    /// Returns one polygon per area name in WKT POLYGON format in UTM Zone 33N.
-    /// Area types: 1 = municipalities, 2 = counties.
-    /// At lower zoom levels shows counties; at higher zoom levels shows municipalities.
+    /// Henter områdemarkører (fylker/kommuner) gruppert etter navn med observasjonsantall.
+    /// Hybrid tilnærming: uten filtre brukes pre-beregnet antall fra Area-tabellen,
+    /// med filtre beregnes antall dynamisk via ObservationEntityIndex.
     /// </summary>
-    public async Task<IEnumerable<AreaMarkerDto>> GetAreaMarkersAsync(int zoomLevel, CancellationToken cancellationToken = default)
+    public async Task<IEnumerable<AreaMarkerDto>> GetAreaMarkersAsync(int zoomLevel, LocationSearchFilterDto? filter = null, CancellationToken cancellationToken = default)
     {
         try
         {
@@ -490,11 +499,30 @@ public class SearchRepository : ISearchRepository
                     .Where(a => a.ZoomLevel == zoomLevel && a.IsCurrent == true)
                     .ToListAsync(cancellationToken);
 
+            var usePrecomputedCounts = filter == null || !filter.HasActiveFilters;
+            Dictionary<(int entityTypeId, int entityId), int>? dynamicCounts = null;
+
+            if (!usePrecomputedCounts)
+            {
+                dynamicCounts = await ComputeFilteredAreaCounts(areas, filter!, cancellationToken);
+            }
+
             return areas
                 .GroupBy(a => a.Name)
                 .Select(g =>
                 {
                     var firstArea = g.FirstOrDefault(a => a.WktPolygon != null) ?? g.First();
+
+                    var count = usePrecomputedCounts
+                        ? g.Sum(a => a.ObservationCount ?? 0)
+                        : g.Sum(a =>
+                        {
+                            var entityId = ConvertSingleFidToInt(a.Fid);
+                            return entityId.HasValue
+                                ? dynamicCounts!.GetValueOrDefault((a.AreaTypeId, entityId.Value), 0)
+                                : 0;
+                        });
+
                     return new AreaMarkerDto
                     {
                         Id = g.Min(a => a.Id),
@@ -503,7 +531,7 @@ public class SearchRepository : ISearchRepository
                         Name = g.Key,
                         AreaTypeId = firstArea.AreaTypeId,
                         ParentFid = firstArea.ParentFid,
-                        ObservationCount = g.Sum(a => a.ObservationCount),
+                        ObservationCount = count,
                         WktsPolygon = firstArea.WktPolygon?.AsText(),
                         Centroid = firstArea.Centroid?.Coordinate != null
                             ? new CentroidDto { X = firstArea.Centroid.Coordinate.X, Y = firstArea.Centroid.Coordinate.Y }
@@ -518,6 +546,37 @@ public class SearchRepository : ISearchRepository
             throw new ApplicationException(
                 "An error occurred while retrieving areas. Please try again later.", ex);
         }
+    }
+
+    /// <summary>
+    /// Beregner filtrerte observasjonsantall per område via ObservationEntityIndex.
+    /// </summary>
+    private async Task<Dictionary<(int entityTypeId, int entityId), int>> ComputeFilteredAreaCounts(
+        List<Area> areas, LocationSearchFilterDto filter, CancellationToken cancellationToken)
+    {
+        var filteredQuery = ApplyCommonFilters(_context.Set<Observation>().AsNoTracking(), filter);
+
+        var entityTypeIds = areas.Select(a => a.AreaTypeId).Distinct().ToArray();
+        var entityIds = areas
+            .Select(a => ConvertSingleFidToInt(a.Fid))
+            .Where(id => id.HasValue)
+            .Select(id => id!.Value)
+            .Distinct()
+            .ToArray();
+
+        var counts = await _context.Set<ObservationEntityIndex>()
+            .Where(idx => entityTypeIds.Contains(idx.EntityTypeId) && entityIds.Contains(idx.EntityId))
+            .Where(idx => filteredQuery.Select(o => o.Id).Contains(idx.ObservationId))
+            .GroupBy(idx => new { idx.EntityTypeId, idx.EntityId })
+            .Select(g => new { g.Key.EntityTypeId, g.Key.EntityId, Count = g.Count() })
+            .ToListAsync(cancellationToken);
+
+        return counts.ToDictionary(x => (x.EntityTypeId, x.EntityId), x => x.Count);
+    }
+
+    private static int? ConvertSingleFidToInt(string fid)
+    {
+        return int.TryParse(fid.Replace("_", ""), out var id) ? id : (int?)null;
     }
 
     /// <summary>

--- a/Artskart3.Infrastructure/Persistence/Repositories/SearchRepository.cs
+++ b/Artskart3.Infrastructure/Persistence/Repositories/SearchRepository.cs
@@ -455,43 +455,44 @@ public class SearchRepository : ISearchRepository
             var hasFilters = filter?.HasActiveFilters == true;
             var needsDynamicCounts = hasFilters && filter!.HasObservationAttributeFilters;
             Dictionary<(int entityTypeId, int entityId), int>? dynamicCounts = null;
-            // Aggregerte kommune-antall per fylke (kun for kommune-filter på fylkesnivå)
             Dictionary<string, int>? municipalityCountsByCounty = null;
 
-            if (hasFilters && !needsDynamicCounts)
+            // Steg 1: Filtrer hvilke områder som vises (uavhengig av tellemåte)
+            var hasAreaSelection = hasFilters && (
+                filter!.CountyIds?.Length > 0 ||
+                filter.MunicipalityIds?.Length > 0 ||
+                filter.OceanAreaIds?.Length > 0);
+
+            if (hasAreaSelection)
             {
                 var filtered = FilterAreasBySelection(areas, filter!);
                 if (filtered.Count > 0)
                 {
-                    var hasMunicipalityFilter = filter!.MunicipalityIds?.Length > 0;
-                    var areasAreCounties = filtered.Any() && !filtered.Any(a => filter.MunicipalityIds?.Contains(a.Fid) == true);
-
-                    if (hasMunicipalityFilter && areasAreCounties)
-                    {
-                        // Kommune-filter på fylkesnivå: summer kommunenes pre-beregnede antall per fylke
-                        municipalityCountsByCounty = await AggregateMunicipalityCountsByCounty(
-                            filter.MunicipalityIds!, cancellationToken);
-                    }
-
                     areas = filtered;
                 }
-                else if (filter!.HasObservationAttributeFilters)
+                else if (!needsDynamicCounts)
                 {
-                    // Områdefiltre matcher ikke på dette zoomnivået, men observasjonsfiltre
-                    // kan endre tellingen — fall tilbake til dynamisk telling.
-                    needsDynamicCounts = true;
-                }
-                else
-                {
-                    // Kun områdefiltre, men ingen matcher dette zoomnivået — ingen markører å vise.
+                    // Ingen områder matcher og ingen observasjonsfiltre — ingen markører å vise
                     areas = filtered;
                 }
             }
 
-            // Observasjonsattributtfiltre (eller fallback): beregn antall dynamisk
+            // Steg 2: Bestem tellemåte
             if (needsDynamicCounts)
             {
                 dynamicCounts = await ComputeFilteredAreaCounts(areas, filter!, cancellationToken);
+            }
+            else if (hasAreaSelection)
+            {
+                // Sjekk om kommune-filter på fylkesnivå krever aggregering
+                var hasMunicipalityFilter = filter!.MunicipalityIds?.Length > 0;
+                var areasAreCounties = areas.Count > 0 && !areas.Any(a => filter.MunicipalityIds?.Contains(a.Fid) == true);
+
+                if (hasMunicipalityFilter && areasAreCounties)
+                {
+                    municipalityCountsByCounty = await AggregateMunicipalityCountsByCounty(
+                        filter.MunicipalityIds!, cancellationToken);
+                }
             }
 
             return areas

--- a/Artskart3.Infrastructure/Services/AreaHierarchyService.cs
+++ b/Artskart3.Infrastructure/Services/AreaHierarchyService.cs
@@ -91,7 +91,10 @@ public class AreaHierarchyService : IAreaHierarchyService, IHostedService, IDisp
                 list.Add(m.Fid);
         }
 
-        // Atomisk swap — lesere ser enten gammel eller ny versjon, aldri delvis oppdatert
+        // Volatile swap — hver referanse settes atomisk, men de to tilordningene er ikke
+        // atomiske samlet. En leser kan i et kort øyeblikk se ny _municipalityToCounty
+        // med gammel _countyToMunicipalities. Akseptabelt fordi data sjelden endres
+        // og en enkelt forespørsel typisk bruker bare én av de to oppslagene.
         _municipalityToCounty = municipalityToCounty;
         _countyToMunicipalities = countyToMunicipalities;
         _initialized = true;

--- a/Artskart3.Infrastructure/Services/AreaHierarchyService.cs
+++ b/Artskart3.Infrastructure/Services/AreaHierarchyService.cs
@@ -1,0 +1,158 @@
+using Artskart3.Core.Application.Persistence;
+using Artskart3.Core.Application.Services.Interfaces;
+using Artskart3.Core.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Artskart3.Infrastructure.Services;
+
+/// <summary>
+/// Oppslag for områdehierarki (kommune→fylke) og Fid→EntityId-konvertering.
+/// Laster data fra Area-tabellen ved oppstart og oppdaterer periodisk.
+/// </summary>
+public class AreaHierarchyService : IAreaHierarchyService, IHostedService, IDisposable
+{
+    private static readonly TimeSpan ReloadInterval = TimeSpan.FromHours(1);
+
+    private volatile Dictionary<string, string> _municipalityToCounty = new();
+    private volatile Dictionary<string, List<string>> _countyToMunicipalities = new();
+    private volatile bool _initialized;
+    private PeriodicTimer? _timer;
+    private Task? _backgroundTask;
+
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<AreaHierarchyService> _logger;
+
+    public AreaHierarchyService(IServiceScopeFactory scopeFactory, ILogger<AreaHierarchyService> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        await LoadAsync(cancellationToken);
+        _timer = new PeriodicTimer(ReloadInterval);
+        _backgroundTask = ReloadLoopAsync();
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        _timer?.Dispose();
+        if (_backgroundTask != null)
+            await _backgroundTask;
+    }
+
+    private async Task ReloadLoopAsync()
+    {
+        while (_timer != null && await _timer.WaitForNextTickAsync())
+        {
+            try
+            {
+                await LoadAsync(CancellationToken.None);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Feil ved periodisk oppdatering av områdehierarki");
+            }
+        }
+    }
+
+    private async Task LoadAsync(CancellationToken cancellationToken)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<IArtsKartDbContext>();
+
+        var areas = await context.Set<Area>()
+            .Where(a => a.IsCurrent)
+            .Select(a => new { a.Fid, a.AreaTypeId, a.ParentFid })
+            .Distinct()
+            .ToListAsync(cancellationToken);
+
+        var municipalityToCounty = new Dictionary<string, string>();
+        var countyToMunicipalities = new Dictionary<string, List<string>>();
+
+        // AreaTypeId 1 = Kommune
+        foreach (var m in areas.Where(a => a.AreaTypeId == 1))
+        {
+            if (string.IsNullOrEmpty(m.ParentFid)) continue;
+
+            municipalityToCounty[m.Fid] = m.ParentFid;
+
+            if (!countyToMunicipalities.TryGetValue(m.ParentFid, out var list))
+            {
+                list = [];
+                countyToMunicipalities[m.ParentFid] = list;
+            }
+
+            if (!list.Contains(m.Fid))
+                list.Add(m.Fid);
+        }
+
+        // Atomisk swap — lesere ser enten gammel eller ny versjon, aldri delvis oppdatert
+        _municipalityToCounty = municipalityToCounty;
+        _countyToMunicipalities = countyToMunicipalities;
+        _initialized = true;
+
+        _logger.LogInformation(
+            "Lastet områdehierarki: {MunicipalityCount} kommuner, {CountyCount} fylker",
+            municipalityToCounty.Count, countyToMunicipalities.Count);
+    }
+
+    public string? GetCountyFid(string municipalityFid)
+    {
+        EnsureInitialized();
+        return _municipalityToCounty.GetValueOrDefault(municipalityFid);
+    }
+
+    public IReadOnlyList<string> GetMunicipalityFids(string countyFid)
+    {
+        EnsureInitialized();
+        return _countyToMunicipalities.TryGetValue(countyFid, out var list)
+            ? list.AsReadOnly()
+            : [];
+    }
+
+    public int? FidToEntityId(string fid)
+    {
+        return int.TryParse(fid.Replace("_", ""), out var id) ? id : null;
+    }
+
+    public int? RestrictedAreaFidToEntityId(string fid)
+    {
+        return int.TryParse(fid.Replace("Naturbase VV", ""), out var id) ? id : null;
+    }
+
+    public int[] FidsToEntityIds(string[]? fids)
+    {
+        if (fids == null || fids.Length == 0) return [];
+        return fids
+            .Select(FidToEntityId)
+            .Where(id => id.HasValue)
+            .Select(id => id!.Value)
+            .ToArray();
+    }
+
+    public int[] RestrictedAreaFidsToEntityIds(string[]? fids)
+    {
+        if (fids == null || fids.Length == 0) return [];
+        return fids
+            .Select(RestrictedAreaFidToEntityId)
+            .Where(id => id.HasValue)
+            .Select(id => id!.Value)
+            .ToArray();
+    }
+
+    private void EnsureInitialized()
+    {
+        if (!_initialized)
+            throw new InvalidOperationException("AreaHierarchyService er ikke initialisert.");
+    }
+
+    public void Dispose()
+    {
+        _timer?.Dispose();
+    }
+}

--- a/Artskart3.Tests.Integration/Fixtures/NotificationsWebApplicationFactory.cs
+++ b/Artskart3.Tests.Integration/Fixtures/NotificationsWebApplicationFactory.cs
@@ -1,11 +1,16 @@
+using Artskart3.Core.Application.Services.Interfaces;
+using Artskart3.Infrastructure.Services;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Artskart3.Tests.Integration.Fixtures;
 
 /// <summary>
 /// Lettvekts WebApplicationFactory for endepunkter som ikke bruker databasen.
 /// Krever ikke Docker — ingen SQL Server-container startes.
+/// Erstatter AreaHierarchyService (hosted service) med en stub som ikke kobler til DB.
 ///
 /// Merk: Dersom notifications-lagringen flyttes fra JSON-fil til SQL Server, må denne
 /// fabrikkklassen erstattes med <see cref="CustomWebApplicationFactory"/> og testklassen
@@ -17,5 +22,18 @@ public sealed class NotificationsWebApplicationFactory : WebApplicationFactory<P
     {
         builder.UseEnvironment("Development");
         builder.UseSetting("Database:AutoMigrate", "false");
+
+        builder.ConfigureServices(services =>
+        {
+            // Fjern AreaHierarchyService (hosted service) som prøver å koble til DB ved oppstart
+            services.RemoveAll<AreaHierarchyService>();
+            services.RemoveAll<IAreaHierarchyService>();
+            var hostedDescriptor = services.FirstOrDefault(d =>
+                d.ServiceType == typeof(Microsoft.Extensions.Hosting.IHostedService) &&
+                d.ImplementationFactory?.Method.ReturnType == typeof(AreaHierarchyService));
+            if (hostedDescriptor != null) services.Remove(hostedDescriptor);
+
+            services.AddSingleton<IAreaHierarchyService, StubAreaHierarchyService>();
+        });
     }
 }

--- a/Artskart3.Tests.Integration/StubAreaHierarchyService.cs
+++ b/Artskart3.Tests.Integration/StubAreaHierarchyService.cs
@@ -1,0 +1,30 @@
+using Artskart3.Core.Application.Services.Interfaces;
+
+namespace Artskart3.Tests.Integration;
+
+/// <summary>
+/// Enkel stub som implementerer IAreaHierarchyService med ren string-parsing.
+/// Brukes i tester som ikke trenger ekte områdehierarki fra databasen.
+/// </summary>
+internal sealed class StubAreaHierarchyService : IAreaHierarchyService
+{
+    public string? GetCountyFid(string municipalityFid) =>
+        municipalityFid.PadLeft(4, '0')[..2];
+
+    public IReadOnlyList<string> GetMunicipalityFids(string countyFid) =>
+        Array.Empty<string>();
+
+    public int? FidToEntityId(string fid) =>
+        int.TryParse(fid.Replace("_", ""), out var id) ? id : null;
+
+    public int? RestrictedAreaFidToEntityId(string fid) =>
+        int.TryParse(fid.Replace("Naturbase VV", ""), out var id) ? id : null;
+
+    public int[] FidsToEntityIds(string[]? fids) =>
+        fids?.Select(f => FidToEntityId(f)).Where(id => id.HasValue).Select(id => id!.Value).ToArray()
+        ?? Array.Empty<int>();
+
+    public int[] RestrictedAreaFidsToEntityIds(string[]? fids) =>
+        fids?.Select(f => RestrictedAreaFidToEntityId(f)).Where(id => id.HasValue).Select(id => id!.Value).ToArray()
+        ?? Array.Empty<int>();
+}

--- a/Artskart3.Tests.Integration/Tests/SearchEndpointTests.cs
+++ b/Artskart3.Tests.Integration/Tests/SearchEndpointTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Http.Json;
 using System.Text.Json;
 using Artskart3.Tests.Integration.Fixtures;
 using FluentAssertions;
@@ -87,13 +88,13 @@ public class SearchEndpointTests : IAsyncLifetime
     }
 
     // -----------------------------------------------------------------------
-    // GET /api/Search/Locations (GetObservationLocations action)
+    // POST /api/Search/Locations (GetObservationLocations action)
     // -----------------------------------------------------------------------
 
     [Fact]
     public async Task GetObservationLocations_WithNoFilter_Returns200WithGeoJson()
     {
-        var response = await _client.GetAsync("/api/Search/Locations");
+        var response = await _client.PostAsJsonAsync("/api/Search/Locations", new { });
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var json = await response.Content.ReadAsStringAsync();
@@ -104,19 +105,19 @@ public class SearchEndpointTests : IAsyncLifetime
     [Fact]
     public async Task GetObservationLocations_WithMaxResultsZero_Returns400()
     {
-        var response = await _client.GetAsync("/api/Search/Locations?filter.MaxResults=0");
+        var response = await _client.PostAsJsonAsync("/api/Search/Locations", new { maxResults = 0 });
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         var json = await response.Content.ReadAsStringAsync();
         json.Should().Contain("error");
-        json.Should().Contain("1").And.Contain("100000"); // Min and Max values 
+        json.Should().Contain("1").And.Contain("100000"); // Min and Max values
     }
 
     [Fact]
     public async Task GetObservationLocations_WithMaxResultsTooHigh_Returns400()
     {
         // MaxLocationResults = 100000, so 100001 exceeds the limit
-        var response = await _client.GetAsync("/api/Search/Locations?filter.MaxResults=100001");
+        var response = await _client.PostAsJsonAsync("/api/Search/Locations", new { maxResults = 100001 });
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         var json = await response.Content.ReadAsStringAsync();
@@ -127,8 +128,8 @@ public class SearchEndpointTests : IAsyncLifetime
     [Fact]
     public async Task GetObservationLocations_WithInvertedPrecisionRange_Returns400()
     {
-        var response = await _client.GetAsync(
-            "/api/Search/Locations?filter.CoordinatePrecision.From=1000&filter.CoordinatePrecision.To=100");
+        var response = await _client.PostAsJsonAsync("/api/Search/Locations",
+            new { coordinatePrecision = new { from = 1000, to = 100 } });
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
@@ -136,7 +137,7 @@ public class SearchEndpointTests : IAsyncLifetime
     [Fact]
     public async Task GetObservationLocations_WithMaxResults10_ReturnsAtMost10Features()
     {
-        var response = await _client.GetAsync("/api/Search/Locations?filter.MaxResults=10");
+        var response = await _client.PostAsJsonAsync("/api/Search/Locations", new { maxResults = 10 });
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var json = await response.Content.ReadAsStringAsync();
@@ -146,13 +147,13 @@ public class SearchEndpointTests : IAsyncLifetime
     }
 
     // -----------------------------------------------------------------------
-    // GET /api/Search/AreaMarkers
+    // POST /api/Search/AreaMarkers
     // -----------------------------------------------------------------------
 
     [Fact]
     public async Task GetAreaMerkers_WithDefaultZoomLevel_Returns200()
     {
-        var response = await _client.GetAsync("/api/Search/AreaMarkers");
+        var response = await _client.PostAsJsonAsync("/api/Search/AreaMarkers?zoomLevel=1", new { });
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         response.Content.Headers.ContentType?.MediaType.Should().Be("application/json");
@@ -161,7 +162,7 @@ public class SearchEndpointTests : IAsyncLifetime
     [Fact]
     public async Task GetAreaMarkers_WithZoomLevel1_Returns200WithJsonArray()
     {
-        var response = await _client.GetAsync("/api/Search/AreaMarkers?zoomLevel=1");
+        var response = await _client.PostAsJsonAsync("/api/Search/AreaMarkers?zoomLevel=1", new { });
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var json = await response.Content.ReadAsStringAsync();
@@ -172,7 +173,7 @@ public class SearchEndpointTests : IAsyncLifetime
     [Fact]
     public async Task GetAreaMarkers_WithZoomLevel2_Returns200WithJsonArray()
     {
-        var response = await _client.GetAsync("/api/Search/AreaMarkers?zoomLevel=2");
+        var response = await _client.PostAsJsonAsync("/api/Search/AreaMarkers?zoomLevel=2", new { });
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var json = await response.Content.ReadAsStringAsync();

--- a/Artskart3.Tests.Integration/Tests/SearchEndpointTests.cs
+++ b/Artskart3.Tests.Integration/Tests/SearchEndpointTests.cs
@@ -128,7 +128,7 @@ public class SearchEndpointTests : IAsyncLifetime
     public async Task GetObservationLocations_WithInvertedPrecisionRange_Returns400()
     {
         var response = await _client.GetAsync(
-            "/api/Search/Locations?filter.CoordinatePrecisionFrom=1000&filter.CoordinatePrecisionTo=100");
+            "/api/Search/Locations?filter.CoordinatePrecision.From=1000&filter.CoordinatePrecision.To=100");
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }

--- a/Artskart3.Tests.Integration/Tests/SearchRepositoryIntegrationTests.cs
+++ b/Artskart3.Tests.Integration/Tests/SearchRepositoryIntegrationTests.cs
@@ -72,10 +72,7 @@ public class SearchRepositoryIntegrationTests : IAsyncLifetime
     [Fact]
     public async Task GetLocationsAsync_GroupsObservationsByLocation()
     {
-        var result = await ToListAsync(_repository.GetLocationsAsync(new LocationSearchFilterDto
-        {
-            CollectionIds = new[] { CollectionOne, CollectionTwo }
-        }));
+        var result = await ToListAsync(_repository.GetLocationsAsync(new LocationSearchFilterDto()));
 
         result.Should().HaveCount(3);
         result.Should().Contain(model => model.Id == _locationOne.Id && model.ObservationCount == 3);
@@ -86,10 +83,7 @@ public class SearchRepositoryIntegrationTests : IAsyncLifetime
     [Fact]
     public async Task GetLocationsAsync_OrdersByObservationCountDescending()
     {
-        var result = await ToListAsync(_repository.GetLocationsAsync(new LocationSearchFilterDto
-        {
-            CollectionIds = new[] { CollectionOne, CollectionTwo }
-        }));
+        var result = await ToListAsync(_repository.GetLocationsAsync(new LocationSearchFilterDto()));
 
         result.Select(x => x.ObservationCount).Should().BeInDescendingOrder();
     }
@@ -112,19 +106,16 @@ public class SearchRepositoryIntegrationTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task GetLocationsAsync_FiltersByTaxonGroupIdAndCollection()
+    public async Task GetLocationsAsync_FiltersByTaxonGroupIdOnly()
     {
         var result = await ToListAsync(_repository.GetLocationsAsync(new LocationSearchFilterDto
         {
-            TaxonGroupIds = new[] { TestObservationTaxonGroupOneId },
-            CollectionIds = new[] { CollectionOne }
+            TaxonGroupIds = new[] { TestObservationTaxonGroupOneId }
         }));
 
-        // Should return only locations with TaxonGroupOneId AND CollectionOne observations
         result.Should().NotBeEmpty();
         result.Select(x => x.Id).Should().Contain(_locationOne.Id);
         result.Select(x => x.Id).Should().Contain(_locationThree.Id);
-        // Should NOT contain location 2 (different taxon group and collection)
         result.Select(x => x.Id).Should().NotContain(_locationTwo.Id);
     }
 
@@ -133,7 +124,7 @@ public class SearchRepositoryIntegrationTests : IAsyncLifetime
     {
         var result = await ToListAsync(_repository.GetLocationsAsync(new LocationSearchFilterDto
         {
-            Categories = new[] { TestCategoryOneId }
+            CategoryIds = new[] { TestCategoryOneId }
         }));
 
         result.Should().ContainSingle();
@@ -145,30 +136,20 @@ public class SearchRepositoryIntegrationTests : IAsyncLifetime
     {
         var result = await ToListAsync(_repository.GetLocationsAsync(new LocationSearchFilterDto
         {
-            BasisOfRecords = new[] { TestBasisOfRecordOneId }
+            BasisOfRecordIds = new[] { TestBasisOfRecordOneId }
         }));
 
         result.Select(location => location.Id).Should().BeEquivalentTo([_locationOne.Id, _locationThree.Id]);
     }
 
-    [Fact]
-    public async Task GetLocationsAsync_FiltersByCollectionId()
-    {
-        var result = await ToListAsync(_repository.GetLocationsAsync(new LocationSearchFilterDto
-        {
-            CollectionIds = new[] { CollectionTwo }
-        }));
-
-        result.Should().ContainSingle();
-        result[0].Id.Should().Be(_locationTwo.Id);
-    }
+    // CollectionId-filtrering er erstattet av OrganizationIds via ObservationEntityIndex.
+    // OrganizationIds-filtrering krever seeding av ObservationEntityIndex-tabellen.
 
     [Fact]
     public async Task GetLocationsAsync_FiltersByCoordinatePrecisionFrom()
     {
         var result = await ToListAsync(_repository.GetLocationsAsync(new LocationSearchFilterDto
         {
-            CollectionIds = new[] { CollectionOne, CollectionTwo },
             CoordinatePrecisionFrom = 100
         }));
 
@@ -180,7 +161,6 @@ public class SearchRepositoryIntegrationTests : IAsyncLifetime
     {
         var result = await ToListAsync(_repository.GetLocationsAsync(new LocationSearchFilterDto
         {
-            CollectionIds = new[] { CollectionOne, CollectionTwo },
             CoordinatePrecisionTo = 50
         }));
 
@@ -193,7 +173,6 @@ public class SearchRepositoryIntegrationTests : IAsyncLifetime
     {
         var result = await ToListAsync(_repository.GetLocationsAsync(new LocationSearchFilterDto
         {
-            CollectionIds = new[] { CollectionOne, CollectionTwo },
             MaxResults = 2
         }));
 

--- a/Artskart3.Tests.Integration/Tests/SearchRepositoryIntegrationTests.cs
+++ b/Artskart3.Tests.Integration/Tests/SearchRepositoryIntegrationTests.cs
@@ -59,7 +59,7 @@ public class SearchRepositoryIntegrationTests : IAsyncLifetime
             .Options;
 
         _context = new ArtskartDbContext(options);
-        _repository = new SearchRepository(_context, NullLogger<SearchRepository>.Instance, Options.Create(new PaginationOptions()));
+        _repository = new SearchRepository(_context, NullLogger<SearchRepository>.Instance, Options.Create(new PaginationOptions()), new StubAreaHierarchyService());
 
         await SeedTestDataAsync();
     }
@@ -72,7 +72,10 @@ public class SearchRepositoryIntegrationTests : IAsyncLifetime
     [Fact]
     public async Task GetLocationsAsync_GroupsObservationsByLocation()
     {
-        var result = await ToListAsync(_repository.GetLocationsAsync(new LocationSearchFilterDto()));
+        var result = await ToListAsync(_repository.GetLocationsAsync(new LocationSearchFilterDto
+        {
+            TaxonGroupIds = new[] { TestObservationTaxonGroupOneId, TestObservationTaxonGroupTwoId }
+        }));
 
         result.Should().HaveCount(3);
         result.Should().Contain(model => model.Id == _locationOne.Id && model.ObservationCount == 3);
@@ -83,7 +86,10 @@ public class SearchRepositoryIntegrationTests : IAsyncLifetime
     [Fact]
     public async Task GetLocationsAsync_OrdersByObservationCountDescending()
     {
-        var result = await ToListAsync(_repository.GetLocationsAsync(new LocationSearchFilterDto()));
+        var result = await ToListAsync(_repository.GetLocationsAsync(new LocationSearchFilterDto
+        {
+            TaxonGroupIds = new[] { TestObservationTaxonGroupOneId, TestObservationTaxonGroupTwoId }
+        }));
 
         result.Select(x => x.ObservationCount).Should().BeInDescendingOrder();
     }
@@ -150,6 +156,7 @@ public class SearchRepositoryIntegrationTests : IAsyncLifetime
     {
         var result = await ToListAsync(_repository.GetLocationsAsync(new LocationSearchFilterDto
         {
+            TaxonGroupIds = new[] { TestObservationTaxonGroupOneId, TestObservationTaxonGroupTwoId },
             CoordinatePrecision = new CoordinatePrecisionDto { From = 100 }
         }));
 
@@ -161,6 +168,7 @@ public class SearchRepositoryIntegrationTests : IAsyncLifetime
     {
         var result = await ToListAsync(_repository.GetLocationsAsync(new LocationSearchFilterDto
         {
+            TaxonGroupIds = new[] { TestObservationTaxonGroupOneId, TestObservationTaxonGroupTwoId },
             CoordinatePrecision = new CoordinatePrecisionDto { To = 50 }
         }));
 
@@ -173,6 +181,7 @@ public class SearchRepositoryIntegrationTests : IAsyncLifetime
     {
         var result = await ToListAsync(_repository.GetLocationsAsync(new LocationSearchFilterDto
         {
+            TaxonGroupIds = new[] { TestObservationTaxonGroupOneId, TestObservationTaxonGroupTwoId },
             MaxResults = 2
         }));
 

--- a/Artskart3.Tests.Integration/Tests/SearchRepositoryIntegrationTests.cs
+++ b/Artskart3.Tests.Integration/Tests/SearchRepositoryIntegrationTests.cs
@@ -150,7 +150,7 @@ public class SearchRepositoryIntegrationTests : IAsyncLifetime
     {
         var result = await ToListAsync(_repository.GetLocationsAsync(new LocationSearchFilterDto
         {
-            CoordinatePrecisionFrom = 100
+            CoordinatePrecision = new CoordinatePrecisionDto { From = 100 }
         }));
 
         result.Select(location => location.Id).Should().BeEquivalentTo([_locationTwo.Id, _locationThree.Id]);
@@ -161,7 +161,7 @@ public class SearchRepositoryIntegrationTests : IAsyncLifetime
     {
         var result = await ToListAsync(_repository.GetLocationsAsync(new LocationSearchFilterDto
         {
-            CoordinatePrecisionTo = 50
+            CoordinatePrecision = new CoordinatePrecisionDto { To = 50 }
         }));
 
         result.Should().ContainSingle();

--- a/Artskart3.Tests.Performance/ObservationSearchBenchmarks.cs
+++ b/Artskart3.Tests.Performance/ObservationSearchBenchmarks.cs
@@ -60,7 +60,7 @@ public class ObservationSearchBenchmarks
             .Options;
 
         _dbContext = new ArtskartDbContext(options);
-        _repository = new SearchRepository(_dbContext, NullLogger<SearchRepository>.Instance, Options.Create(new PaginationOptions()));
+        _repository = new SearchRepository(_dbContext, NullLogger<SearchRepository>.Instance, Options.Create(new PaginationOptions()), new StubAreaHierarchyService());
     }
 
     [GlobalCleanup]

--- a/Artskart3.Tests.Performance/SearchServiceBenchmarks.cs
+++ b/Artskart3.Tests.Performance/SearchServiceBenchmarks.cs
@@ -113,8 +113,7 @@ public class SearchServiceBenchmarks
     {
         _ = await _searchService.GetLocationsAsync(new LocationSearchFilterDto
         {
-            CoordinatePrecisionFrom = 1,
-            CoordinatePrecisionTo = 100,
+            CoordinatePrecision = new CoordinatePrecisionDto { From = 1, To = 100 },
             MaxResults = 1000
         });
     }
@@ -125,8 +124,7 @@ public class SearchServiceBenchmarks
         _ = await _searchService.GetLocationsAsync(new LocationSearchFilterDto
         {
             TaxonGroupIds = new[] { 1 },
-            CoordinatePrecisionFrom = 1,
-            CoordinatePrecisionTo = 1000,
+            CoordinatePrecision = new CoordinatePrecisionDto { From = 1, To = 1000 },
             MaxResults = 500
         });
     }

--- a/Artskart3.Tests.Performance/SearchServiceBenchmarks.cs
+++ b/Artskart3.Tests.Performance/SearchServiceBenchmarks.cs
@@ -49,7 +49,7 @@ public class SearchServiceBenchmarks
 
         _dbContext = new ArtskartDbContext(options);
 
-        var repository = new SearchRepository(_dbContext, NullLogger<SearchRepository>.Instance, Options.Create(new PaginationOptions()));
+        var repository = new SearchRepository(_dbContext, NullLogger<SearchRepository>.Instance, Options.Create(new PaginationOptions()), new StubAreaHierarchyService());
         _searchService = new SearchService(repository, new MemoryCache(new MemoryCacheOptions()));
     }
 

--- a/Artskart3.Tests.Performance/StubAreaHierarchyService.cs
+++ b/Artskart3.Tests.Performance/StubAreaHierarchyService.cs
@@ -1,0 +1,30 @@
+using Artskart3.Core.Application.Services.Interfaces;
+
+namespace Artskart3.Tests.Performance;
+
+/// <summary>
+/// Enkel stub som implementerer IAreaHierarchyService med ren string-parsing.
+/// Brukes i benchmarks som ikke trenger ekte områdehierarki fra databasen.
+/// </summary>
+internal sealed class StubAreaHierarchyService : IAreaHierarchyService
+{
+    public string? GetCountyFid(string municipalityFid) =>
+        municipalityFid.PadLeft(4, '0')[..2];
+
+    public IReadOnlyList<string> GetMunicipalityFids(string countyFid) =>
+        Array.Empty<string>();
+
+    public int? FidToEntityId(string fid) =>
+        int.TryParse(fid.Replace("_", ""), out var id) ? id : null;
+
+    public int? RestrictedAreaFidToEntityId(string fid) =>
+        int.TryParse(fid.Replace("Naturbase VV", ""), out var id) ? id : null;
+
+    public int[] FidsToEntityIds(string[]? fids) =>
+        fids?.Select(f => FidToEntityId(f)).Where(id => id.HasValue).Select(id => id!.Value).ToArray()
+        ?? Array.Empty<int>();
+
+    public int[] RestrictedAreaFidsToEntityIds(string[]? fids) =>
+        fids?.Select(f => RestrictedAreaFidToEntityId(f)).Where(id => id.HasValue).Select(id => id!.Value).ToArray()
+        ?? Array.Empty<int>();
+}

--- a/Artskart3.Tests.Unit/LocationSearchFilterDtoTests.cs
+++ b/Artskart3.Tests.Unit/LocationSearchFilterDtoTests.cs
@@ -43,21 +43,32 @@ public class LocationSearchFilterDtoTests
         var sut = new LocationSearchFilterDto
         {
             TaxonGroupIds = new[] { 1, 2 },
-            Categories = new[] { 3, 4 },
-            BasisOfRecords = new[] { 5, 6 },
-            CollectionIds = new[] { "NHM", "GBIF" },
+            CategoryIds = new[] { 3, 4 },
+            BasisOfRecordIds = new[] { 5, 6 },
+            OrganizationIds = new[] { 7, 8 },
+            MunicipalityIds = new[] { "0301", "1103" },
+            CountyIds = new[] { "03", "11" },
+            OceanAreaIds = new[] { "500" },
+            BehaviorIds = new[] { 9, 10 },
             CoordinatePrecisionFrom = 10,
             CoordinatePrecisionTo = 100,
+            Period = new PeriodDto { From = 2000, To = 2024 },
             Epsg = 25833,
             MaxResults = 250
         };
 
         sut.TaxonGroupIds.Should().BeEquivalentTo(new[] { 1, 2 });
-        sut.Categories.Should().BeEquivalentTo(new[] { 3, 4 });
-        sut.BasisOfRecords.Should().BeEquivalentTo(new[] { 5, 6 });
-        sut.CollectionIds.Should().BeEquivalentTo(new[] { "NHM", "GBIF" });
+        sut.CategoryIds.Should().BeEquivalentTo(new[] { 3, 4 });
+        sut.BasisOfRecordIds.Should().BeEquivalentTo(new[] { 5, 6 });
+        sut.OrganizationIds.Should().BeEquivalentTo(new[] { 7, 8 });
+        sut.MunicipalityIds.Should().BeEquivalentTo(new[] { "0301", "1103" });
+        sut.CountyIds.Should().BeEquivalentTo(new[] { "03", "11" });
+        sut.OceanAreaIds.Should().BeEquivalentTo(new[] { "500" });
+        sut.BehaviorIds.Should().BeEquivalentTo(new[] { 9, 10 });
         sut.CoordinatePrecisionFrom.Should().Be(10);
         sut.CoordinatePrecisionTo.Should().Be(100);
+        sut.Period!.From.Should().Be(2000);
+        sut.Period!.To.Should().Be(2024);
         sut.Epsg.Should().Be(25833);
         sut.MaxResults.Should().Be(250);
     }

--- a/Artskart3.Tests.Unit/LocationSearchFilterDtoTests.cs
+++ b/Artskart3.Tests.Unit/LocationSearchFilterDtoTests.cs
@@ -14,19 +14,11 @@ public class LocationSearchFilterDtoTests
     }
 
     [Fact]
-    public void CoordinatePrecisionFrom_HarStandardverdi0()
+    public void CoordinatePrecision_ErNullSomStandard()
     {
         var sut = new LocationSearchFilterDto();
 
-        sut.CoordinatePrecisionFrom.Should().Be(0);
-    }
-
-    [Fact]
-    public void CoordinatePrecisionTo_HarStandardverdi0()
-    {
-        var sut = new LocationSearchFilterDto();
-
-        sut.CoordinatePrecisionTo.Should().Be(0);
+        sut.CoordinatePrecision.Should().BeNull();
     }
 
     [Fact]
@@ -50,8 +42,7 @@ public class LocationSearchFilterDtoTests
             CountyIds = new[] { "03", "11" },
             OceanAreaIds = new[] { "500" },
             BehaviorIds = new[] { 9, 10 },
-            CoordinatePrecisionFrom = 10,
-            CoordinatePrecisionTo = 100,
+            CoordinatePrecision = new CoordinatePrecisionDto { From = 10, To = 100 },
             Period = new PeriodDto { From = 2000, To = 2024 },
             Epsg = 25833,
             MaxResults = 250
@@ -65,8 +56,8 @@ public class LocationSearchFilterDtoTests
         sut.CountyIds.Should().BeEquivalentTo(new[] { "03", "11" });
         sut.OceanAreaIds.Should().BeEquivalentTo(new[] { "500" });
         sut.BehaviorIds.Should().BeEquivalentTo(new[] { 9, 10 });
-        sut.CoordinatePrecisionFrom.Should().Be(10);
-        sut.CoordinatePrecisionTo.Should().Be(100);
+        sut.CoordinatePrecision!.From.Should().Be(10);
+        sut.CoordinatePrecision!.To.Should().Be(100);
         sut.Period!.From.Should().Be(2000);
         sut.Period!.To.Should().Be(2024);
         sut.Epsg.Should().Be(25833);

--- a/Artskart3.Tests.Unit/SearchControllerAdditionalTests.cs
+++ b/Artskart3.Tests.Unit/SearchControllerAdditionalTests.cs
@@ -52,12 +52,13 @@ public class SearchControllerAdditionalTests
             .Setup(s => s.GetLocationsAsync(It.IsAny<LocationSearchFilterDto>()))
             .ReturnsAsync("{\"type\":\"FeatureCollection\",\"features\":[]}");
 
-        var result = await sut.GetObservationLocations(new LocationSearchFilterDto { CoordinatePrecisionFrom = 10, CoordinatePrecisionTo = 0 });
+        var result = await sut.GetObservationLocations(new LocationSearchFilterDto { CoordinatePrecision = new CoordinatePrecisionDto { From = 10 } });
 
         result.Result.Should().BeOfType<ContentResult>();
         _serviceMock.Verify(s => s.GetLocationsAsync(It.Is<LocationSearchFilterDto>(f =>
-            f.CoordinatePrecisionFrom == 10 &&
-            f.CoordinatePrecisionTo == 0)), Times.Once);
+            f.CoordinatePrecision != null &&
+            f.CoordinatePrecision.From == 10 &&
+            f.CoordinatePrecision.To == null)), Times.Once);
     }
 
     [Fact]
@@ -68,12 +69,13 @@ public class SearchControllerAdditionalTests
             .Setup(s => s.GetLocationsAsync(It.IsAny<LocationSearchFilterDto>()))
             .ReturnsAsync("{\"type\":\"FeatureCollection\",\"features\":[]}");
 
-        var result = await sut.GetObservationLocations(new LocationSearchFilterDto { CoordinatePrecisionFrom = 0, CoordinatePrecisionTo = 100 });
+        var result = await sut.GetObservationLocations(new LocationSearchFilterDto { CoordinatePrecision = new CoordinatePrecisionDto { To = 100 } });
 
         result.Result.Should().BeOfType<ContentResult>();
         _serviceMock.Verify(s => s.GetLocationsAsync(It.Is<LocationSearchFilterDto>(f =>
-            f.CoordinatePrecisionFrom == 0 &&
-            f.CoordinatePrecisionTo == 100)), Times.Once);
+            f.CoordinatePrecision != null &&
+            f.CoordinatePrecision.From == null &&
+            f.CoordinatePrecision.To == 100)), Times.Once);
     }
 
     private SearchController CreateSut() => new(_serviceMock.Object, _loggerMock.Object);

--- a/Artskart3.Tests.Unit/SearchControllerTests.cs
+++ b/Artskart3.Tests.Unit/SearchControllerTests.cs
@@ -110,8 +110,7 @@ public class SearchControllerTests
     {
         var filter = new LocationSearchFilterDto
         {
-            CoordinatePrecisionFrom = 500,
-            CoordinatePrecisionTo = 100
+            CoordinatePrecision = new CoordinatePrecisionDto { From = 500, To = 100 }
         };
 
         var result = await _sut.GetObservationLocations(filter);

--- a/Artskart3.Tests.Unit/SearchRepositoryTests.cs
+++ b/Artskart3.Tests.Unit/SearchRepositoryTests.cs
@@ -135,7 +135,7 @@ public class SearchRepositoryTests
 
         await context.SaveChangesAsync();
 
-        var result = await ToListAsync(sut.GetLocationsAsync(new LocationSearchFilterDto { Categories = new[] { 10 } }));
+        var result = await ToListAsync(sut.GetLocationsAsync(new LocationSearchFilterDto { CategoryIds = new[] { 10 } }));
 
         result.Should().ContainSingle();
         result[0].Id.Should().Be(1);
@@ -157,33 +157,14 @@ public class SearchRepositoryTests
 
         await context.SaveChangesAsync();
 
-        var result = await ToListAsync(sut.GetLocationsAsync(new LocationSearchFilterDto { BasisOfRecords = new[] { 5 } }));
+        var result = await ToListAsync(sut.GetLocationsAsync(new LocationSearchFilterDto { BasisOfRecordIds = new[] { 5 } }));
 
         result.Should().ContainSingle();
         result[0].Id.Should().Be(1);
     }
 
-    [Fact]
-    public async Task GetLocationsAsync_WithCollectionIdFilter_ReturnsOnlyMatchingLocations()
-    {
-        await using var context = CreateInMemoryContext();
-        var sut = CreateRepository(context);
-
-        SeedLocations(context,
-            CreateLocation(1, "Oslo"),
-            CreateLocation(2, "Trondheim"));
-
-        SeedObservations(context,
-            CreateObservation(1, 1, institutionCode: "NHM"),
-            CreateObservation(2, 2, institutionCode: "GBIF"));
-
-        await context.SaveChangesAsync();
-
-        var result = await ToListAsync(sut.GetLocationsAsync(new LocationSearchFilterDto { CollectionIds = new[] { "NHM" } }));
-
-        result.Should().ContainSingle();
-        result[0].Id.Should().Be(1);
-    }
+    // CollectionId-filtrering er erstattet av OrganizationIds via ObservationEntityIndex.
+    // Denne testen krever seeding av ObservationEntityIndex og dekkes av integrasjonstester.
 
     [Fact]
     public async Task GetLocationsAsync_WithCoordinatePrecisionFromFilter_FiltersCorrectly()

--- a/Artskart3.Tests.Unit/SearchRepositoryTests.cs
+++ b/Artskart3.Tests.Unit/SearchRepositoryTests.cs
@@ -18,7 +18,7 @@ public class SearchRepositoryTests
     public async Task GetTaxonsAsync_WithNullName_ReturnsEmpty()
     {
         var contextMock = new Mock<IArtsKartDbContext>();
-        var sut = new SearchRepository(contextMock.Object, NullLogger<SearchRepository>.Instance, Options.Create(new PaginationOptions()));
+        var sut = new SearchRepository(contextMock.Object, NullLogger<SearchRepository>.Instance, Options.Create(new PaginationOptions()), new StubAreaHierarchyService());
 
         var result = await sut.GetTaxonsAsync(null!);
 
@@ -30,7 +30,7 @@ public class SearchRepositoryTests
     public async Task GetTaxonsAsync_WithWhitespaceName_ReturnsEmpty()
     {
         var contextMock = new Mock<IArtsKartDbContext>();
-        var sut = new SearchRepository(contextMock.Object, NullLogger<SearchRepository>.Instance, Options.Create(new PaginationOptions()));
+        var sut = new SearchRepository(contextMock.Object, NullLogger<SearchRepository>.Instance, Options.Create(new PaginationOptions()), new StubAreaHierarchyService());
 
         var result = await sut.GetTaxonsAsync("   ");
 
@@ -42,7 +42,7 @@ public class SearchRepositoryTests
     public async Task GetTaxonsAsync_WithMaxCountZero_ThrowsArgumentException()
     {
         var contextMock = new Mock<IArtsKartDbContext>();
-        var sut = new SearchRepository(contextMock.Object, NullLogger<SearchRepository>.Instance, Options.Create(new PaginationOptions()));
+        var sut = new SearchRepository(contextMock.Object, NullLogger<SearchRepository>.Instance, Options.Create(new PaginationOptions()), new StubAreaHierarchyService());
 
         var act = () => sut.GetTaxonsAsync("fugl", 0);
 
@@ -54,7 +54,7 @@ public class SearchRepositoryTests
     public async Task GetTaxonsAsync_WithMaxCountTooHigh_ThrowsArgumentException()
     {
         var contextMock = new Mock<IArtsKartDbContext>();
-        var sut = new SearchRepository(contextMock.Object, NullLogger<SearchRepository>.Instance, Options.Create(new PaginationOptions()));
+        var sut = new SearchRepository(contextMock.Object, NullLogger<SearchRepository>.Instance, Options.Create(new PaginationOptions()), new StubAreaHierarchyService());
 
         var act = () => sut.GetTaxonsAsync("fugl", 1001);
 
@@ -66,7 +66,7 @@ public class SearchRepositoryTests
     public async Task GetTaxonsAsync_WithNegativeMaxCount_ThrowsArgumentException()
     {
         var contextMock = new Mock<IArtsKartDbContext>();
-        var sut = new SearchRepository(contextMock.Object, NullLogger<SearchRepository>.Instance, Options.Create(new PaginationOptions()));
+        var sut = new SearchRepository(contextMock.Object, NullLogger<SearchRepository>.Instance, Options.Create(new PaginationOptions()), new StubAreaHierarchyService());
 
         var act = () => sut.GetTaxonsAsync("fugl", -1);
 
@@ -419,7 +419,7 @@ public class SearchRepositoryTests
     }
 
     private static SearchRepository CreateRepository(ArtskartDbContext context) =>
-        new(context, NullLogger<SearchRepository>.Instance, Options.Create(new PaginationOptions()));
+        new(context, NullLogger<SearchRepository>.Instance, Options.Create(new PaginationOptions()), new StubAreaHierarchyService());
 
     private static void SeedLocations(ArtskartDbContext context, params Location[] locations) =>
         context.Set<Location>().AddRange(locations);

--- a/Artskart3.Tests.Unit/SearchRepositoryTests.cs
+++ b/Artskart3.Tests.Unit/SearchRepositoryTests.cs
@@ -184,7 +184,7 @@ public class SearchRepositoryTests
 
         await context.SaveChangesAsync();
 
-        var result = await ToListAsync(sut.GetLocationsAsync(new LocationSearchFilterDto { CoordinatePrecisionFrom = 50 }));
+        var result = await ToListAsync(sut.GetLocationsAsync(new LocationSearchFilterDto { CoordinatePrecision = new CoordinatePrecisionDto { From = 50 } }));
 
         result.Select(x => x.Id).Should().BeEquivalentTo([2, 3]);
     }
@@ -207,7 +207,7 @@ public class SearchRepositoryTests
 
         await context.SaveChangesAsync();
 
-        var result = await ToListAsync(sut.GetLocationsAsync(new LocationSearchFilterDto { CoordinatePrecisionTo = 50 }));
+        var result = await ToListAsync(sut.GetLocationsAsync(new LocationSearchFilterDto { CoordinatePrecision = new CoordinatePrecisionDto { To = 50 } }));
 
         result.Select(x => x.Id).Should().BeEquivalentTo([1, 2]);
     }
@@ -232,8 +232,7 @@ public class SearchRepositoryTests
 
         var result = await ToListAsync(sut.GetLocationsAsync(new LocationSearchFilterDto
         {
-            CoordinatePrecisionFrom = 25,
-            CoordinatePrecisionTo = 75
+            CoordinatePrecision = new CoordinatePrecisionDto { From = 25, To = 75 }
         }));
 
         result.Should().ContainSingle();

--- a/Artskart3.Tests.Unit/StubAreaHierarchyService.cs
+++ b/Artskart3.Tests.Unit/StubAreaHierarchyService.cs
@@ -1,0 +1,30 @@
+using Artskart3.Core.Application.Services.Interfaces;
+
+namespace Artskart3.Tests.Unit;
+
+/// <summary>
+/// Enkel stub som implementerer IAreaHierarchyService med ren string-parsing.
+/// Brukes i tester som ikke trenger ekte områdehierarki fra databasen.
+/// </summary>
+internal sealed class StubAreaHierarchyService : IAreaHierarchyService
+{
+    public string? GetCountyFid(string municipalityFid) =>
+        municipalityFid.PadLeft(4, '0')[..2];
+
+    public IReadOnlyList<string> GetMunicipalityFids(string countyFid) =>
+        Array.Empty<string>();
+
+    public int? FidToEntityId(string fid) =>
+        int.TryParse(fid.Replace("_", ""), out var id) ? id : null;
+
+    public int? RestrictedAreaFidToEntityId(string fid) =>
+        int.TryParse(fid.Replace("Naturbase VV", ""), out var id) ? id : null;
+
+    public int[] FidsToEntityIds(string[]? fids) =>
+        fids?.Select(f => FidToEntityId(f)).Where(id => id.HasValue).Select(id => id!.Value).ToArray()
+        ?? Array.Empty<int>();
+
+    public int[] RestrictedAreaFidsToEntityIds(string[]? fids) =>
+        fids?.Select(f => RestrictedAreaFidToEntityId(f)).Where(id => id.HasValue).Select(id => id!.Value).ToArray()
+        ?? Array.Empty<int>();
+}

--- a/Artskart3.WebApp/src/app/core/services/api-client.service.ts
+++ b/Artskart3.WebApp/src/app/core/services/api-client.service.ts
@@ -36,6 +36,22 @@ export class ApiClientService {
     );
   }
 
+  postJson<T>(endpoint: string, body: unknown, options?: { responseType?: 'json' | 'text' }): Observable<T> {
+    const responseType = options?.responseType ?? 'json';
+
+    const request$ = responseType === 'text'
+      ? (this.http.post(endpoint, body, { responseType: 'text' }) as Observable<T>)
+      : this.http.post<T>(endpoint, body);
+
+    return request$.pipe(
+      retry({
+        delay: RetryConfig.InitialDelayMs,
+        count: RetryConfig.MaxAttempts - 1
+      }),
+      catchError(error => this.handleError(error, `Failed to post ${endpoint}`))
+    );
+  }
+
   parseJsonResponse<T>(responseText: string, context?: string): T {
     if (!responseText?.trim()) {
       const msg = `Empty response from ${context || 'API'}`;

--- a/Artskart3.WebApp/src/app/core/services/areas/areas.service.ts
+++ b/Artskart3.WebApp/src/app/core/services/areas/areas.service.ts
@@ -269,6 +269,21 @@ function calculateClippedCentroid(parsed: ParsedGeometry, extent: [number, numbe
   return ensureInsideRing([largest.cx, largest.cy], largest.ring);
 }
 
+export interface LocationSearchFilter {
+  categoryIds?: number[];
+  organizationIds?: number[];
+  behaviorIds?: number[];
+  basisOfRecordIds?: number[];
+  taxonGroupIds?: number[];
+  countyIds?: string[];
+  municipalityIds?: string[];
+  oceanAreaIds?: string[];
+  coordinatePrecisionFrom?: number | null;
+  coordinatePrecisionTo?: number | null;
+  periodFrom?: number | null;
+  periodTo?: number | null;
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -308,13 +323,37 @@ export class AreasService {
    * Fetches locations as a serialized GeoJSON FeatureCollection string
    * with per-feature `nbic:style` for direct use with `updateGeoJSONLayer`.
    * @param extent Kartutsnitt [minX, minY, maxX, maxY] i EPSG:25833
+   * @param filter Valgfritt søkefilter for lokasjoner
    */
-  getLocationsAsGeoJsonString(extent?: [number, number, number, number]): Observable<string> {
-    let url = this.locationsEndpoint;
+  getLocationsAsGeoJsonString(extent?: [number, number, number, number], filter?: LocationSearchFilter): Observable<string> {
+    const params = new URLSearchParams();
+
     if (extent) {
       const [minX, minY, maxX, maxY] = extent;
-      url += `?Envelope.MinX=${minX}&Envelope.MinY=${minY}&Envelope.MaxX=${maxX}&Envelope.MaxY=${maxY}`;
+      params.set('Envelope.MinX', String(minX));
+      params.set('Envelope.MinY', String(minY));
+      params.set('Envelope.MaxX', String(maxX));
+      params.set('Envelope.MaxY', String(maxY));
     }
+
+    if (filter) {
+      this.appendArrayParam(params, 'CategoryIds', filter.categoryIds);
+      this.appendArrayParam(params, 'OrganizationIds', filter.organizationIds);
+      this.appendArrayParam(params, 'BehaviorIds', filter.behaviorIds);
+      this.appendArrayParam(params, 'BasisOfRecordIds', filter.basisOfRecordIds);
+      this.appendArrayParam(params, 'TaxonGroupIds', filter.taxonGroupIds);
+      this.appendArrayParam(params, 'CountyIds', filter.countyIds);
+      this.appendArrayParam(params, 'MunicipalityIds', filter.municipalityIds);
+      this.appendArrayParam(params, 'OceanAreaIds', filter.oceanAreaIds);
+      if (filter.coordinatePrecisionFrom != null) params.set('CoordinatePrecisionFrom', String(filter.coordinatePrecisionFrom));
+      if (filter.coordinatePrecisionTo != null) params.set('CoordinatePrecisionTo', String(filter.coordinatePrecisionTo));
+      if (filter.periodFrom != null) params.set('Period.From', String(filter.periodFrom));
+      if (filter.periodTo != null) params.set('Period.To', String(filter.periodTo));
+    }
+
+    const queryString = params.toString();
+    const url = queryString ? `${this.locationsEndpoint}?${queryString}` : this.locationsEndpoint;
+
     return this.apiClientService.fetchJson<string>(url, { responseType: 'text' }).pipe(
       map((responseText: string) => {
         const parsed = this.apiClientService.parseJsonResponse<unknown>(responseText, AreasService.SERVICE_NAME);
@@ -323,6 +362,13 @@ export class AreasService {
         return JSON.stringify({ type: 'FeatureCollection', features });
       })
     );
+  }
+
+  private appendArrayParam(params: URLSearchParams, name: string, values?: (string | number)[]): void {
+    if (!values?.length) return;
+    for (const v of values) {
+      params.append(name, String(v));
+    }
   }
 
   /**

--- a/Artskart3.WebApp/src/app/core/services/areas/areas.service.ts
+++ b/Artskart3.WebApp/src/app/core/services/areas/areas.service.ts
@@ -277,6 +277,7 @@ export interface LocationSearchFilter {
   taxonGroupIds?: number[];
   countyIds?: string[];
   municipalityIds?: string[];
+  restrictedAreaIds?: string[];
   oceanAreaIds?: string[];
   coordinatePrecisionFrom?: number | null;
   coordinatePrecisionTo?: number | null;
@@ -351,6 +352,7 @@ export class AreasService {
       if (filter.taxonGroupIds?.length) body['taxonGroupIds'] = filter.taxonGroupIds;
       if (filter.countyIds?.length) body['countyIds'] = filter.countyIds;
       if (filter.municipalityIds?.length) body['municipalityIds'] = filter.municipalityIds;
+      if (filter.restrictedAreaIds?.length) body['restrictedAreaIds'] = filter.restrictedAreaIds;
       if (filter.oceanAreaIds?.length) body['oceanAreaIds'] = filter.oceanAreaIds;
       if (filter.coordinatePrecisionFrom != null || filter.coordinatePrecisionTo != null) {
         body['coordinatePrecision'] = { from: filter.coordinatePrecisionFrom, to: filter.coordinatePrecisionTo };

--- a/Artskart3.WebApp/src/app/core/services/areas/areas.service.ts
+++ b/Artskart3.WebApp/src/app/core/services/areas/areas.service.ts
@@ -308,26 +308,10 @@ export class AreasService {
     }
 
     const apiZoomLevel = ZoomConfig.getApiZoomLevel(validation.normalized!);
-    const params = new URLSearchParams();
-    params.set('zoomLevel', String(apiZoomLevel));
-
-    if (filter) {
-      this.appendArrayParam(params, 'CategoryIds', filter.categoryIds);
-      this.appendArrayParam(params, 'OrganizationIds', filter.organizationIds);
-      this.appendArrayParam(params, 'BehaviorIds', filter.behaviorIds);
-      this.appendArrayParam(params, 'BasisOfRecordIds', filter.basisOfRecordIds);
-      this.appendArrayParam(params, 'TaxonGroupIds', filter.taxonGroupIds);
-      this.appendArrayParam(params, 'CountyIds', filter.countyIds);
-      this.appendArrayParam(params, 'MunicipalityIds', filter.municipalityIds);
-      this.appendArrayParam(params, 'OceanAreaIds', filter.oceanAreaIds);
-      if (filter.coordinatePrecisionFrom != null) params.set('CoordinatePrecision.From', String(filter.coordinatePrecisionFrom));
-      if (filter.coordinatePrecisionTo != null) params.set('CoordinatePrecision.To', String(filter.coordinatePrecisionTo));
-      if (filter.periodFrom != null) params.set('Period.From', String(filter.periodFrom));
-      if (filter.periodTo != null) params.set('Period.To', String(filter.periodTo));
-    }
+    const body = this.buildFilterBody(filter);
 
     return this.apiClientService
-      .fetchJson<string>(`${this.areasBaseEndpoint}?${params.toString()}`, { responseType: 'text' })
+      .postJson<string>(`${this.areasBaseEndpoint}?zoomLevel=${apiZoomLevel}`, body, { responseType: 'text' })
       .pipe(
         map(responseText => {
           const areas = this.apiClientService.parseJsonResponse<AreaMarkerDto[]>(responseText, AreasService.SERVICE_NAME);
@@ -344,35 +328,9 @@ export class AreasService {
    * @param filter Valgfritt søkefilter for lokasjoner
    */
   getLocationsAsGeoJsonString(extent?: [number, number, number, number], filter?: LocationSearchFilter): Observable<string> {
-    const params = new URLSearchParams();
+    const body = this.buildFilterBody(filter, extent);
 
-    if (extent) {
-      const [minX, minY, maxX, maxY] = extent;
-      params.set('Envelope.MinX', String(minX));
-      params.set('Envelope.MinY', String(minY));
-      params.set('Envelope.MaxX', String(maxX));
-      params.set('Envelope.MaxY', String(maxY));
-    }
-
-    if (filter) {
-      this.appendArrayParam(params, 'CategoryIds', filter.categoryIds);
-      this.appendArrayParam(params, 'OrganizationIds', filter.organizationIds);
-      this.appendArrayParam(params, 'BehaviorIds', filter.behaviorIds);
-      this.appendArrayParam(params, 'BasisOfRecordIds', filter.basisOfRecordIds);
-      this.appendArrayParam(params, 'TaxonGroupIds', filter.taxonGroupIds);
-      this.appendArrayParam(params, 'CountyIds', filter.countyIds);
-      this.appendArrayParam(params, 'MunicipalityIds', filter.municipalityIds);
-      this.appendArrayParam(params, 'OceanAreaIds', filter.oceanAreaIds);
-      if (filter.coordinatePrecisionFrom != null) params.set('CoordinatePrecision.From', String(filter.coordinatePrecisionFrom));
-      if (filter.coordinatePrecisionTo != null) params.set('CoordinatePrecision.To', String(filter.coordinatePrecisionTo));
-      if (filter.periodFrom != null) params.set('Period.From', String(filter.periodFrom));
-      if (filter.periodTo != null) params.set('Period.To', String(filter.periodTo));
-    }
-
-    const queryString = params.toString();
-    const url = queryString ? `${this.locationsEndpoint}?${queryString}` : this.locationsEndpoint;
-
-    return this.apiClientService.fetchJson<string>(url, { responseType: 'text' }).pipe(
+    return this.apiClientService.postJson<string>(this.locationsEndpoint, body, { responseType: 'text' }).pipe(
       map((responseText: string) => {
         const parsed = this.apiClientService.parseJsonResponse<unknown>(responseText, AreasService.SERVICE_NAME);
         const features = this.mapLocationsToGeoJson(parsed);
@@ -382,11 +340,32 @@ export class AreasService {
     );
   }
 
-  private appendArrayParam(params: URLSearchParams, name: string, values?: (string | number)[]): void {
-    if (!values?.length) return;
-    for (const v of values) {
-      params.append(name, String(v));
+  private buildFilterBody(filter?: LocationSearchFilter, extent?: [number, number, number, number]): Record<string, unknown> {
+    const body: Record<string, unknown> = {};
+
+    if (filter) {
+      if (filter.categoryIds?.length) body['categoryIds'] = filter.categoryIds;
+      if (filter.organizationIds?.length) body['organizationIds'] = filter.organizationIds;
+      if (filter.behaviorIds?.length) body['behaviorIds'] = filter.behaviorIds;
+      if (filter.basisOfRecordIds?.length) body['basisOfRecordIds'] = filter.basisOfRecordIds;
+      if (filter.taxonGroupIds?.length) body['taxonGroupIds'] = filter.taxonGroupIds;
+      if (filter.countyIds?.length) body['countyIds'] = filter.countyIds;
+      if (filter.municipalityIds?.length) body['municipalityIds'] = filter.municipalityIds;
+      if (filter.oceanAreaIds?.length) body['oceanAreaIds'] = filter.oceanAreaIds;
+      if (filter.coordinatePrecisionFrom != null || filter.coordinatePrecisionTo != null) {
+        body['coordinatePrecision'] = { from: filter.coordinatePrecisionFrom, to: filter.coordinatePrecisionTo };
+      }
+      if (filter.periodFrom != null || filter.periodTo != null) {
+        body['period'] = { from: filter.periodFrom, to: filter.periodTo };
+      }
     }
+
+    if (extent) {
+      const [minX, minY, maxX, maxY] = extent;
+      body['envelope'] = { minX, minY, maxX, maxY };
+    }
+
+    return body;
   }
 
   /**

--- a/Artskart3.WebApp/src/app/core/services/areas/areas.service.ts
+++ b/Artskart3.WebApp/src/app/core/services/areas/areas.service.ts
@@ -299,17 +299,35 @@ export class AreasService {
 
   /**
    * Henter områdemarkører fra API for gitt zoomnivå.
+   * @param filter Valgfritt søkefilter — brukes til dynamisk telling av observasjoner per område
    */
-  getAreaMarkers(openLayerZoom: number): Observable<AreaMarkerDto[]> {
+  getAreaMarkers(openLayerZoom: number, filter?: LocationSearchFilter): Observable<AreaMarkerDto[]> {
     const validation = this.validationService.validateZoomLevel(openLayerZoom);
     if (!validation.valid) {
       throw new Error(validation.error || ApiMessages.Errors.InvalidParameters);
     }
 
     const apiZoomLevel = ZoomConfig.getApiZoomLevel(validation.normalized!);
+    const params = new URLSearchParams();
+    params.set('zoomLevel', String(apiZoomLevel));
+
+    if (filter) {
+      this.appendArrayParam(params, 'CategoryIds', filter.categoryIds);
+      this.appendArrayParam(params, 'OrganizationIds', filter.organizationIds);
+      this.appendArrayParam(params, 'BehaviorIds', filter.behaviorIds);
+      this.appendArrayParam(params, 'BasisOfRecordIds', filter.basisOfRecordIds);
+      this.appendArrayParam(params, 'TaxonGroupIds', filter.taxonGroupIds);
+      this.appendArrayParam(params, 'CountyIds', filter.countyIds);
+      this.appendArrayParam(params, 'MunicipalityIds', filter.municipalityIds);
+      this.appendArrayParam(params, 'OceanAreaIds', filter.oceanAreaIds);
+      if (filter.coordinatePrecisionFrom != null) params.set('CoordinatePrecision.From', String(filter.coordinatePrecisionFrom));
+      if (filter.coordinatePrecisionTo != null) params.set('CoordinatePrecision.To', String(filter.coordinatePrecisionTo));
+      if (filter.periodFrom != null) params.set('Period.From', String(filter.periodFrom));
+      if (filter.periodTo != null) params.set('Period.To', String(filter.periodTo));
+    }
 
     return this.apiClientService
-      .fetchJson<string>(`${this.areasBaseEndpoint}?zoomLevel=${apiZoomLevel}`, { responseType: 'text' })
+      .fetchJson<string>(`${this.areasBaseEndpoint}?${params.toString()}`, { responseType: 'text' })
       .pipe(
         map(responseText => {
           const areas = this.apiClientService.parseJsonResponse<AreaMarkerDto[]>(responseText, AreasService.SERVICE_NAME);
@@ -345,8 +363,8 @@ export class AreasService {
       this.appendArrayParam(params, 'CountyIds', filter.countyIds);
       this.appendArrayParam(params, 'MunicipalityIds', filter.municipalityIds);
       this.appendArrayParam(params, 'OceanAreaIds', filter.oceanAreaIds);
-      if (filter.coordinatePrecisionFrom != null) params.set('CoordinatePrecisionFrom', String(filter.coordinatePrecisionFrom));
-      if (filter.coordinatePrecisionTo != null) params.set('CoordinatePrecisionTo', String(filter.coordinatePrecisionTo));
+      if (filter.coordinatePrecisionFrom != null) params.set('CoordinatePrecision.From', String(filter.coordinatePrecisionFrom));
+      if (filter.coordinatePrecisionTo != null) params.set('CoordinatePrecision.To', String(filter.coordinatePrecisionTo));
       if (filter.periodFrom != null) params.set('Period.From', String(filter.periodFrom));
       if (filter.periodTo != null) params.set('Period.To', String(filter.periodTo));
     }

--- a/Artskart3.WebApp/src/app/shared/components/map.component/map.component.ts
+++ b/Artskart3.WebApp/src/app/shared/components/map.component/map.component.ts
@@ -13,11 +13,13 @@ import {
   ViewChild,
   OnDestroy,
   inject,
+  computed,
+  effect,
 } from '@angular/core';
 import { LoggingService } from '@shared/logging.service';
 import { Subject, EMPTY } from 'rxjs';
 import { catchError, debounceTime, switchMap, takeUntil, tap } from 'rxjs/operators';
-import { AreasService } from '@core/services/areas/areas.service';
+import { AreasService, LocationSearchFilter } from '@core/services/areas/areas.service';
 import { AreaMarkerDto } from '@shared/models/area/area-marker.model';
 import { ZoomConfig } from '@shared/helpers/zoom/zoom-config';
 import { MAP_CONFIG } from '@shared/config/map.config';
@@ -26,6 +28,8 @@ import { SharedMapService } from '../../services/shared-map.service';
 import { MapToolbarComponent } from './map-toolbar/map-toolbar.component';
 import { ImageTile } from 'ol';
 import { ApiZoomLevel } from './map.types';
+import { FilterStateService } from '../../services/filter-state/filter-state.service';
+import { AreaService } from '../../services/area/area.service';
 
 @Component({
   selector: 'app-map',
@@ -45,6 +49,7 @@ export class MapComponent implements AfterViewInit, OnDestroy {
 
   public map!: NbicMapComponent;
   private areaDataCacheByApiZoom = new Map<number, AreaMarkerDto[]>();
+  private mapReady = false;
 
   private destroy$ = new Subject<void>();
   private fetchAreaData$ = new Subject<{ apiZoomLevel: number; olZoom: number; extent: [number, number, number, number] }>();
@@ -52,6 +57,41 @@ export class MapComponent implements AfterViewInit, OnDestroy {
   private readonly areasService = inject(AreasService);
   private readonly sharedMapService = inject(SharedMapService);
   private readonly logger = inject(LoggingService);
+  private readonly filterState = inject(FilterStateService);
+  private readonly areaService = inject(AreaService);
+
+  private readonly locationFilter = computed<LocationSearchFilter>(
+    () => {
+      const { countyIds, municipalityIds } = this.areaService.resolvedAreaFilter();
+      const coordinatePrecisionFrom = this.filterState.coordinatePrecisionFrom();
+      const coordinatePrecisionTo = this.filterState.coordinatePrecisionTo();
+      const periodFrom = this.filterState.periodFrom();
+      const periodTo = this.filterState.periodTo();
+
+      return {
+        categoryIds: this.filterState.selectedCategoryIds().length ? this.filterState.selectedCategoryIds() : undefined,
+        organizationIds: this.filterState.selectedInstitutionIds().length ? this.filterState.selectedInstitutionIds() : undefined,
+        behaviorIds: this.filterState.selectedBehaviorIds().length ? this.filterState.selectedBehaviorIds() : undefined,
+        basisOfRecordIds: this.filterState.selectedBasisOfRecordIds().length ? this.filterState.selectedBasisOfRecordIds() : undefined,
+        taxonGroupIds: this.filterState.selectedTaxonGroupIds().length ? this.filterState.selectedTaxonGroupIds() : undefined,
+        countyIds: countyIds.length ? countyIds : undefined,
+        municipalityIds: municipalityIds.length ? municipalityIds : undefined,
+        oceanAreaIds: this.filterState.selectedOceanAreaIds().length ? this.filterState.selectedOceanAreaIds() : undefined,
+        coordinatePrecisionFrom: coordinatePrecisionFrom,
+        coordinatePrecisionTo: coordinatePrecisionTo,
+        periodFrom: periodFrom,
+        periodTo: periodTo,
+      };
+    },
+    { equal: (a, b) => JSON.stringify(a) === JSON.stringify(b) },
+  );
+
+  private readonly _refetchOnFilterChange = effect(() => {
+    this.locationFilter();
+    if (this.mapReady) {
+      this.emitFetchEvent();
+    }
+  });
 
   ngAfterViewInit(): void {
     setTimeout(() => this.initializeMap(), MAP_CONFIG.initDelay);
@@ -112,6 +152,7 @@ export class MapComponent implements AfterViewInit, OnDestroy {
   }
 
   private onMapReady(): void {
+    this.mapReady = true;
     this.mapReadyAction.emit(true);
     if (!this.map) return;
     this.map.activateHoverInfo();
@@ -203,7 +244,8 @@ export class MapComponent implements AfterViewInit, OnDestroy {
           );
         }
 
-        return this.areasService.getLocationsAsGeoJsonString(extent).pipe(
+        const filter = this.locationFilter();
+        return this.areasService.getLocationsAsGeoJsonString(extent, filter).pipe(
           tap(geojson => {
             this.applyGeoJsonToLayer(apiZoomLevel, geojson);
           }),

--- a/Artskart3.WebApp/src/app/shared/components/map.component/map.component.ts
+++ b/Artskart3.WebApp/src/app/shared/components/map.component/map.component.ts
@@ -89,6 +89,7 @@ export class MapComponent implements AfterViewInit, OnDestroy {
   private readonly _refetchOnFilterChange = effect(() => {
     this.locationFilter();
     if (this.mapReady) {
+      this.areaDataCacheByApiZoom.clear();
       this.emitFetchEvent();
     }
   });
@@ -231,7 +232,8 @@ export class MapComponent implements AfterViewInit, OnDestroy {
             return EMPTY;
           }
 
-          return this.areasService.getAreaMarkers(olZoom).pipe(
+          const filter = this.locationFilter();
+          return this.areasService.getAreaMarkers(olZoom, filter).pipe(
             tap(areas => {
               this.areaDataCacheByApiZoom.set(apiZoomLevel, areas);
               const geojson = this.areasService.buildAreaGeoJson(areas, extent);

--- a/Artskart3.WebApp/src/app/shared/types/api.generated.ts
+++ b/Artskart3.WebApp/src/app/shared/types/api.generated.ts
@@ -259,29 +259,20 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        get: {
+        get?: never;
+        put?: never;
+        post: {
             parameters: {
-                query?: {
-                    TaxonGroupIds?: number[];
-                    CategoryIds?: number[];
-                    BasisOfRecordIds?: number[];
-                    OrganizationIds?: number[];
-                    MunicipalityIds?: string[];
-                    CountyIds?: string[];
-                    OceanAreaIds?: string[];
-                    BehaviorIds?: number[];
-                    "CoordinatePrecision.From"?: number;
-                    "CoordinatePrecision.To"?: number;
-                    "Period.From"?: number;
-                    "Period.To"?: number;
-                    Epsg?: number;
-                    MaxResults?: number;
-                };
+                query?: never;
                 header?: never;
                 path?: never;
                 cookie?: never;
             };
-            requestBody?: never;
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["LocationSearchFilterDto"];
+                };
+            };
             responses: {
                 /** @description OK */
                 200: {
@@ -294,8 +285,6 @@ export interface paths {
                 };
             };
         };
-        put?: never;
-        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -350,29 +339,22 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        get: {
+        get?: never;
+        put?: never;
+        post: {
             parameters: {
                 query?: {
                     zoomLevel?: number;
-                    TaxonGroupIds?: number[];
-                    CategoryIds?: number[];
-                    BasisOfRecordIds?: number[];
-                    OrganizationIds?: number[];
-                    MunicipalityIds?: string[];
-                    CountyIds?: string[];
-                    RestrictedAreaIds?: string[];
-                    OceanAreaIds?: string[];
-                    BehaviorIds?: number[];
-                    "CoordinatePrecision.From"?: number;
-                    "CoordinatePrecision.To"?: number;
-                    "Period.From"?: number;
-                    "Period.To"?: number;
                 };
                 header?: never;
                 path?: never;
                 cookie?: never;
             };
-            requestBody?: never;
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["LocationSearchFilterDto"];
+                };
+            };
             responses: {
                 /** @description OK */
                 200: {
@@ -385,8 +367,6 @@ export interface paths {
                 };
             };
         };
-        put?: never;
-        post?: never;
         delete?: never;
         options?: never;
         head?: never;
@@ -467,6 +447,29 @@ export interface components {
             id?: number;
             name?: string | null;
             areas?: components["schemas"]["AreaDto"][] | null;
+        };
+        LocationSearchFilterDto: {
+            taxonGroupIds?: number[] | null;
+            categoryIds?: number[] | null;
+            basisOfRecordIds?: number[] | null;
+            organizationIds?: number[] | null;
+            municipalityIds?: string[] | null;
+            countyIds?: string[] | null;
+            restrictedAreaIds?: string[] | null;
+            oceanAreaIds?: string[] | null;
+            behaviorIds?: number[] | null;
+            coordinatePrecision?: components["schemas"]["CoordinatePrecisionDto"];
+            period?: components["schemas"]["PeriodDto"];
+            /** Format: int32 */
+            epsg?: number | null;
+            /** Format: int32 */
+            maxResults?: number;
+            envelope?: {
+                minX?: number;
+                minY?: number;
+                maxX?: number;
+                maxY?: number;
+            } | null;
         };
         BasisOfRecordDto: {
             /** Format: int32 */

--- a/Artskart3.WebApp/src/app/shared/types/api.generated.ts
+++ b/Artskart3.WebApp/src/app/shared/types/api.generated.ts
@@ -263,11 +263,17 @@ export interface paths {
             parameters: {
                 query?: {
                     TaxonGroupIds?: number[];
-                    Categories?: number[];
-                    BasisOfRecords?: number[];
-                    CollectionIds?: string[];
+                    CategoryIds?: number[];
+                    BasisOfRecordIds?: number[];
+                    OrganizationIds?: number[];
+                    MunicipalityIds?: string[];
+                    CountyIds?: string[];
+                    OceanAreaIds?: string[];
+                    BehaviorIds?: number[];
                     CoordinatePrecisionFrom?: number;
                     CoordinatePrecisionTo?: number;
+                    "Period.From"?: number;
+                    "Period.To"?: number;
                     Epsg?: number;
                     MaxResults?: number;
                 };

--- a/Artskart3.WebApp/src/app/shared/types/api.generated.ts
+++ b/Artskart3.WebApp/src/app/shared/types/api.generated.ts
@@ -270,8 +270,8 @@ export interface paths {
                     CountyIds?: string[];
                     OceanAreaIds?: string[];
                     BehaviorIds?: number[];
-                    CoordinatePrecisionFrom?: number;
-                    CoordinatePrecisionTo?: number;
+                    "CoordinatePrecision.From"?: number;
+                    "CoordinatePrecision.To"?: number;
                     "Period.From"?: number;
                     "Period.To"?: number;
                     Epsg?: number;
@@ -354,6 +354,19 @@ export interface paths {
             parameters: {
                 query?: {
                     zoomLevel?: number;
+                    TaxonGroupIds?: number[];
+                    CategoryIds?: number[];
+                    BasisOfRecordIds?: number[];
+                    OrganizationIds?: number[];
+                    MunicipalityIds?: string[];
+                    CountyIds?: string[];
+                    RestrictedAreaIds?: string[];
+                    OceanAreaIds?: string[];
+                    BehaviorIds?: number[];
+                    "CoordinatePrecision.From"?: number;
+                    "CoordinatePrecision.To"?: number;
+                    "Period.From"?: number;
+                    "Period.To"?: number;
                 };
                 header?: never;
                 path?: never;


### PR DESCRIPTION
Filter på kart:
  - Kartkomponenten leser nå filterstatus via Angular-signaler og oppdaterer kartet automatisk når filtre endres
  - Både Locations- og AreaMarkers-endepunktene støtter nå alle filtre (taksongruppe, kategori, område, atferd, presisjon, periode, etc.)

  DTO-opprydding:
  - CollectionIds → OrganizationIds (bruker nå ObservationEntityIndex i stedet for direkte InstitutionCode-matching)
  - Categories → CategoryIds, BasisOfRecords → BasisOfRecordIds (konsistent navngivning med observasjons-DTOen)
  - Flat CoordinatePrecisionFrom/To → CoordinatePrecisionDto (samme struktur som observasjoner)
  - Felles IObservationFilter-interface deles mellom begge DTO-ene for å unngå duplisert filterlogikk

  API-konsistens:
  - Locations og AreaMarkers endret fra GET med query-parametere til POST med JSON body (likt Observation-endepunktet)

  Hybrid ytelsesoptimalisering for områdemarkører:
  - Ingen filtre → pre-beregnede antall fra Area-tabellen (cachet)
  - Kun fylke/kommune/havområde-filter → filtrerer hvilke markører som vises, pre-beregnede antall
  - Kommune-filter på fylkesnivå → aggregerer kommunenes antall per forelder-fylke
  - Observasjonsattributtfiltre → dynamisk telling via ObservationEntityIndex

  AreaHierarchyService:
  - Singleton som laster kommune→fylke-oppslag fra databasen ved oppstart
  - Periodisk oppdatering (1 time) via IHostedService
  - Erstatter all string-parsing av Fid-er (PadLeft/Substring-konvensjonen)

  Database-migrering (ImproveFilterQueryIndexes):
  - Nytt dekkende indeks: ObservationEntityIndex(EntityTypeId, EntityId, ObservationId)
  - Nytt indeks: Observation(DateTimeCollected) for periodefiltrering
  - Nytt indeks: Area(ZoomLevel, IsCurrent) for områdemarkør-spørringer
  - Fjernet 2 redundante indekser som det nye dekker