### PR TITLE
#316 Fixed bug

### DIFF
--- a/Artskart3.Api/Program.cs
+++ b/Artskart3.Api/Program.cs
@@ -119,10 +119,10 @@ try
     }
 
     var dbConnectionString = builder.Configuration.GetConnectionString("ArtskartIndex");
-    if (string.IsNullOrEmpty(dbConnectionString))
-        throw new InvalidOperationException(
-            "Connection string 'ArtskartIndex' is not configured. " +
-            "For local development, use 'dotnet user-secrets set \"ConnectionStrings:ArtskartIndex\" \"<your-connection-string>\"'.");
+    //if (string.IsNullOrEmpty(dbConnectionString))
+    //    throw new InvalidOperationException(
+    //        "Connection string 'ArtskartIndex' is not configured. " +
+    //        "For local development, use 'dotnet user-secrets set \"ConnectionStrings:ArtskartIndex\" \"<your-connection-string>\"'.");
 
     builder.Services.AddBff()
         .ConfigureOpenIdConnect(options =>

--- a/Artskart3.Api/Program.cs
+++ b/Artskart3.Api/Program.cs
@@ -119,6 +119,11 @@ try
     }
 
     var dbConnectionString = builder.Configuration.GetConnectionString("ArtskartIndex");
+    if (string.IsNullOrEmpty(dbConnectionString))
+        throw new InvalidOperationException(
+            "Connection string 'ArtskartIndex' is not configured. " +
+            "For local development, use 'dotnet user-secrets set \"ConnectionStrings:ArtskartIndex\" \"<your-connection-string>\"'.");
+
     builder.Services.AddBff()
         .ConfigureOpenIdConnect(options =>
         {


### PR DESCRIPTION
Hvis connection string er null eller tom i Azure eller på utviklingsmaskinen da får vi ett kræsj i koden.

Vi ønsker å gi en forståelig feilmelding her og fanger derfor denne feilen med en catch exception.