### PR TITLE
migrate map controls to adopted OL controls via nbic-map-component

### DIFF
--- a/Artskart3.WebApp/src/app/shared/components/map.component/controls/control-utils.ts
+++ b/Artskart3.WebApp/src/app/shared/components/map.component/controls/control-utils.ts
@@ -1,0 +1,5 @@
+export function createSvgIcon(svg: string): HTMLSpanElement {
+  const span = document.createElement('span');
+  span.innerHTML = svg;
+  return span;
+}

--- a/Artskart3.WebApp/src/app/shared/components/map.component/controls/fullscreen.control.ts
+++ b/Artskart3.WebApp/src/app/shared/components/map.component/controls/fullscreen.control.ts
@@ -1,0 +1,34 @@
+import FullScreen from 'ol/control/FullScreen';
+import { createSvgIcon } from './control-utils';
+
+const FULLSCREEN_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+  <path d="M5 19V13H7V17H11V19H5ZM17 11V7H13V5H19V11H17Z" fill="currentColor"/>
+</svg>`;
+
+const EXIT_FULLSCREEN_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+  <path d="M9 19V15H5V13H11V19H9ZM13 11V5H15V9H19V11H13Z" fill="currentColor"/>
+</svg>`;
+
+export interface FullscreenControlLabels {
+  tipLabel: string;
+}
+
+export class ArtskartFullscreenControl extends FullScreen {
+  constructor(labels: FullscreenControlLabels) {
+    super({
+      className: 'artskart-fullscreen',
+      label: createSvgIcon(FULLSCREEN_SVG),
+      labelActive: createSvgIcon(EXIT_FULLSCREEN_SVG),
+      tipLabel: labels.tipLabel,
+    });
+    this.updateLabels(labels);
+  }
+
+  updateLabels(labels: FullscreenControlLabels): void {
+    const button = this.element.querySelector('button');
+    if (button) {
+      button.title = '';
+      button.setAttribute('aria-label', labels.tipLabel);
+    }
+  }
+}

--- a/Artskart3.WebApp/src/app/shared/components/map.component/controls/geolocation.control.ts
+++ b/Artskart3.WebApp/src/app/shared/components/map.component/controls/geolocation.control.ts
@@ -1,0 +1,127 @@
+import Control from 'ol/control/Control';
+
+const GEOLOCATION_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+  <path d="M10.9998 22.95V20.95C8.91647 20.7167 7.12897 19.8542 5.6373 18.3625C4.14564 16.8709 3.28314 15.0834 3.0498 13H1.0498V11H3.0498C3.28314 8.91672 4.14564 7.12922 5.6373 5.63755C7.12897 4.14588 8.91647 3.28338 10.9998 3.05005V1.05005H12.9998V3.05005C15.0831 3.28338 16.8706 4.14588 18.3623 5.63755C19.854 7.12922 20.7165 8.91672 20.9498 11H22.9498V13H20.9498C20.7165 15.0834 19.854 16.8709 18.3623 18.3625C16.8706 19.8542 15.0831 20.7167 12.9998 20.95V22.95H10.9998ZM11.9998 19C13.9331 19 15.5831 18.3167 16.9498 16.95C18.3165 15.5834 18.9998 13.9334 18.9998 12C18.9998 10.0667 18.3165 8.41672 16.9498 7.05005C15.5831 5.68338 13.9331 5.00005 11.9998 5.00005C10.0665 5.00005 8.41647 5.68338 7.0498 7.05005C5.68314 8.41672 4.9998 10.0667 4.9998 12C4.9998 13.9334 5.68314 15.5834 7.0498 16.95C8.41647 18.3167 10.0665 19 11.9998 19ZM11.9998 16C10.8998 16 9.95814 15.6084 9.1748 14.825C8.39147 14.0417 7.9998 13.1 7.9998 12C7.9998 10.9 8.39147 9.95838 9.1748 9.17505C9.95814 8.39172 10.8998 8.00005 11.9998 8.00005C13.0998 8.00005 14.0415 8.39172 14.8248 9.17505C15.6081 9.95838 15.9998 10.9 15.9998 12C15.9998 13.1 15.6081 14.0417 14.8248 14.825C14.0415 15.6084 13.0998 16 11.9998 16ZM11.9998 14C12.5498 14 13.0206 13.8042 13.4123 13.4125C13.804 13.0209 13.9998 12.55 13.9998 12C13.9998 11.45 13.804 10.9792 13.4123 10.5875C13.0206 10.1959 12.5498 10 11.9998 10C11.4498 10 10.979 10.1959 10.5873 10.5875C10.1956 10.9792 9.9998 11.45 9.9998 12C9.9998 12.55 10.1956 13.0209 10.5873 13.4125C10.979 13.8042 11.4498 14 11.9998 14Z" fill="currentColor"/>
+</svg>`;
+
+export interface GeolocationControlLabels {
+  tipLabel: string;
+  deniedTooltip: string;
+}
+
+export interface GeolocationControlCallbacks {
+  onClick: () => Promise<unknown>;
+}
+
+export class GeolocationMapControl extends Control {
+  private button: HTMLButtonElement;
+  private tooltip: HTMLSpanElement;
+  private denied = false;
+  private permissionStatus: PermissionStatus | null = null;
+  private readonly tooltipId = `geolocation-denied-tooltip-${Math.random().toString(36).slice(2, 8)}`;
+
+  constructor(
+    labels: GeolocationControlLabels,
+    private callbacks: GeolocationControlCallbacks,
+  ) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'artskart-geolocation-btn';
+    button.innerHTML = GEOLOCATION_SVG;
+    button.setAttribute('aria-label', labels.tipLabel);
+
+    const tooltip = document.createElement('span');
+    tooltip.className = 'artskart-geolocation-tooltip';
+    tooltip.setAttribute('role', 'tooltip');
+    tooltip.textContent = labels.deniedTooltip;
+
+    const wrapper = document.createElement('div');
+    wrapper.className = 'artskart-geolocation-wrapper';
+    wrapper.appendChild(button);
+    wrapper.appendChild(tooltip);
+
+    const element = document.createElement('div');
+    element.className = 'artskart-geolocation ol-unselectable ol-control';
+    element.appendChild(wrapper);
+
+    super({ element });
+    this.button = button;
+    this.tooltip = tooltip;
+
+    button.addEventListener('click', () => this.handleClick());
+
+    this.queryPermission();
+  }
+
+  override dispose(): void {
+    if (this.permissionStatus) {
+      this.permissionStatus.onchange = null;
+      this.permissionStatus = null;
+    }
+    super.dispose();
+  }
+
+  setDenied(denied: boolean): void {
+    this.denied = denied;
+    this.button.disabled = denied;
+    this.tooltip.classList.toggle('artskart-geolocation-tooltip--visible', denied);
+    if (denied) {
+      this.button.setAttribute('aria-describedby', this.tooltipId);
+      this.tooltip.id = this.tooltipId;
+    } else {
+      this.button.removeAttribute('aria-describedby');
+      this.tooltip.removeAttribute('id');
+    }
+  }
+
+  updateLabels(labels: GeolocationControlLabels): void {
+    this.button.setAttribute('aria-label', labels.tipLabel);
+    this.tooltip.textContent = labels.deniedTooltip;
+  }
+
+  private async handleClick(): Promise<void> {
+    if (this.denied) return;
+
+    const permissionGranted = await new Promise<boolean>((resolve) => {
+      navigator.geolocation.getCurrentPosition(
+        () => resolve(true),
+        (error) => resolve(error.code !== 1),
+        { timeout: 5000, maximumAge: Infinity },
+      );
+    });
+
+    if (!permissionGranted) {
+      this.setDenied(true);
+      return;
+    }
+
+    try {
+      await this.callbacks.onClick();
+    } catch (error) {
+      // Map zoom failed but permission was granted — don't disable button
+      console.error("Map zoom failed but permission was granted — don't disable button", error);
+    }
+  }
+
+  private queryPermission(): void {
+    if (!navigator.permissions) return;
+
+    navigator.permissions
+      .query({ name: 'geolocation' })
+      .then((status) => {
+        this.permissionStatus = status;
+        if (status.state === 'denied') {
+          this.setDenied(true);
+        }
+        status.onchange = () => this.setDenied(status.state === 'denied');
+      })
+      .catch(() => {
+        // Permissions API not supported for geolocation in this browser
+        console.warn('Permissions API not supported for geolocation in this browser');
+      });
+  }
+}
+
+export function createGeolocationControl(labels: GeolocationControlLabels, callbacks: GeolocationControlCallbacks): GeolocationMapControl {
+  return new GeolocationMapControl(labels, callbacks);
+}

--- a/Artskart3.WebApp/src/app/shared/components/map.component/controls/zoom.control.ts
+++ b/Artskart3.WebApp/src/app/shared/components/map.component/controls/zoom.control.ts
@@ -1,0 +1,43 @@
+import Zoom from 'ol/control/Zoom';
+import { createSvgIcon } from './control-utils';
+
+const ZOOM_IN_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+  <path d="M11 13H5V11H11V5H13V11H19V13H13V19H11V13Z" fill="currentColor"/>
+</svg>`;
+
+const ZOOM_OUT_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+  <path d="M5 11H19V13H5V11Z" fill="currentColor"/>
+</svg>`;
+
+export interface ZoomControlLabels {
+  zoomInTipLabel: string;
+  zoomOutTipLabel: string;
+}
+
+export class ArtskartZoomControl extends Zoom {
+  constructor(labels: ZoomControlLabels) {
+    super({
+      className: 'artskart-zoom',
+      zoomInClassName: 'artskart-zoom-in',
+      zoomOutClassName: 'artskart-zoom-out',
+      zoomInLabel: createSvgIcon(ZOOM_IN_SVG),
+      zoomOutLabel: createSvgIcon(ZOOM_OUT_SVG),
+      zoomInTipLabel: labels.zoomInTipLabel,
+      zoomOutTipLabel: labels.zoomOutTipLabel,
+    });
+    // OL sets title from tipLabel — clear it and use aria-label instead
+    this.updateLabels(labels);
+  }
+
+  updateLabels(labels: ZoomControlLabels): void {
+    const buttons = this.element.querySelectorAll('button');
+    if (buttons[0]) {
+      buttons[0].title = '';
+      buttons[0].setAttribute('aria-label', labels.zoomInTipLabel);
+    }
+    if (buttons[1]) {
+      buttons[1].title = '';
+      buttons[1].setAttribute('aria-label', labels.zoomOutTipLabel);
+    }
+  }
+}

--- a/Artskart3.WebApp/src/app/shared/components/map.component/map-toolbar/map-toolbar.component.css
+++ b/Artskart3.WebApp/src/app/shared/components/map.component/map-toolbar/map-toolbar.component.css
@@ -7,23 +7,17 @@
   pointer-events: none;
 }
 
-.map-toolbar-top,
-  .map-toolbar-right {
-    position: absolute;
-    right: 12px;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 8px;
-    z-index: 100;
-    pointer-events: auto;
-  }
-  .map-toolbar-top {
-    top: 20px;
-  }
-  .map-toolbar-right {
-    bottom: 20px;
-  }
+.map-toolbar-top {
+  position: absolute;
+  right: 12px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  z-index: 100;
+  pointer-events: auto;
+  top: 20px;
+}
 
 adb-icon-button[disabled] {
   cursor: not-allowed;
@@ -37,30 +31,4 @@ adb-icon-button {
 
 .hidden-not-implemented {
   display: none;
-}
-
-.tooltip-wrapper {
-  position: relative;
-}
-
-.toolbar-tooltip {
-  display: none;
-  position: absolute;
-  right: calc(100% + 8px);
-  top: 50%;
-  transform: translateY(-50%);
-  background: #333;
-  color: #fff;
-  font-size: 13px;
-  line-height: 1.4;
-  padding: 6px 10px;
-  border-radius: 4px;
-  white-space: nowrap;
-  pointer-events: none;
-  z-index: 200;
-}
-
-.tooltip-wrapper:hover .toolbar-tooltip,
-.tooltip-wrapper:focus-within .toolbar-tooltip {
-  display: block;
 }

--- a/Artskart3.WebApp/src/app/shared/components/map.component/map-toolbar/map-toolbar.component.html
+++ b/Artskart3.WebApp/src/app/shared/components/map.component/map-toolbar/map-toolbar.component.html
@@ -2,50 +2,51 @@
   <!-- Top Controls -->
   <div class="map-toolbar-top">
     <app-map-type-selector (mapTypeSelected)="onMapTypeSelected($event)"></app-map-type-selector>
-    <adb-icon-button class="hidden-not-implemented" variant="secondary" disabled [attr.data-action]="toolbarActions.LAYERS" (click)="onButtonClick(toolbarActions.LAYERS)" [attr.aria-label]="'mapToolbar.layersAriaLabel' | translate">
+    <adb-icon-button
+      class="hidden-not-implemented"
+      variant="secondary"
+      disabled
+      [attr.data-action]="toolbarActions.LAYERS"
+      (click)="onButtonClick(toolbarActions.LAYERS)"
+      [attr.aria-label]="'mapToolbar.layersAriaLabel' | translate"
+    >
       <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-        <path d="M12 21.05L3 14.05L4.65 12.8L12 18.5L19.35 12.8L21 14.05L12 21.05ZM12 16L3 9L12 2L21 9L12 16ZM12 13.45L17.75 9L12 4.55L6.25 9L12 13.45Z" fill="currentColor"/>
+        <path
+          d="M12 21.05L3 14.05L4.65 12.8L12 18.5L19.35 12.8L21 14.05L12 21.05ZM12 16L3 9L12 2L21 9L12 16ZM12 13.45L17.75 9L12 4.55L6.25 9L12 13.45Z"
+          fill="currentColor"
+        />
       </svg>
     </adb-icon-button>
-    <adb-icon-button class="hidden-not-implemented" variant="secondary" disabled [attr.data-action]="toolbarActions.FILTER" (click)="onButtonClick(toolbarActions.FILTER)" [attr.aria-label]="'mapToolbar.filterAriaLabel' | translate">
+    <adb-icon-button
+      class="hidden-not-implemented"
+      variant="secondary"
+      disabled
+      [attr.data-action]="toolbarActions.FILTER"
+      (click)="onButtonClick(toolbarActions.FILTER)"
+      [attr.aria-label]="'mapToolbar.filterAriaLabel' | translate"
+    >
       <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-        <path d="M11 21V15H13V17H21V19H13V21H11ZM3 19V17H9V19H3ZM7 15V13H3V11H7V9H9V15H7ZM11 13V11H21V13H11ZM15 9V3H17V5H21V7H17V9H15ZM3 7V5H13V7H3Z" fill="currentColor"/>
+        <path
+          d="M11 21V15H13V17H21V19H13V21H11ZM3 19V17H9V19H3ZM7 15V13H3V11H7V9H9V15H7ZM11 13V11H21V13H11ZM15 9V3H17V5H21V7H17V9H15ZM3 7V5H13V7H3Z"
+          fill="currentColor"
+        />
       </svg>
     </adb-icon-button>
-    <adb-icon-button class="hidden-not-implemented" variant="secondary" disabled [attr.data-action]="toolbarActions.POLYGON" (click)="onButtonClick(toolbarActions.POLYGON)" [attr.aria-label]="'mapToolbar.polygonAriaLabel' | translate">
+    <adb-icon-button
+      class="hidden-not-implemented"
+      variant="secondary"
+      disabled
+      [attr.data-action]="toolbarActions.POLYGON"
+      (click)="onButtonClick(toolbarActions.POLYGON)"
+      [attr.aria-label]="'mapToolbar.polygonAriaLabel' | translate"
+    >
       <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-        <path fill-rule="evenodd" clip-rule="evenodd" d="M15 19.5V22H21V16H18.7208L16 7.83772V2H10V6.9L7.3 10H3V16H8L15 19.5ZM13.9459 8H11.7L9 11.1V14.25L15 17.25V16H16.6126L13.9459 8ZM14 6H12V4H14V6ZM7 14H5V12H7V14ZM19 20H17V18H19V20Z" fill="currentColor"/>
-      </svg>
-    </adb-icon-button>
-  </div>
-
-  <!-- Right Controls -->
-  <div class="map-toolbar-right">
-    <div class="tooltip-wrapper">
-      <adb-icon-button variant="secondary" [attr.data-action]="toolbarActions.GEOLOCATION" (click)="onButtonClick(toolbarActions.GEOLOCATION)" [attr.aria-label]="'mapToolbar.geolocationAriaLabel' | translate" [disabled]="geolocationDenied()" [attr.aria-describedby]="geolocationDenied() ? 'geolocation-denied-tooltip' : null">
-        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-          <path d="M10.9998 22.95V20.95C8.91647 20.7167 7.12897 19.8542 5.6373 18.3625C4.14564 16.8709 3.28314 15.0834 3.0498 13H1.0498V11H3.0498C3.28314 8.91672 4.14564 7.12922 5.6373 5.63755C7.12897 4.14588 8.91647 3.28338 10.9998 3.05005V1.05005H12.9998V3.05005C15.0831 3.28338 16.8706 4.14588 18.3623 5.63755C19.854 7.12922 20.7165 8.91672 20.9498 11H22.9498V13H20.9498C20.7165 15.0834 19.854 16.8709 18.3623 18.3625C16.8706 19.8542 15.0831 20.7167 12.9998 20.95V22.95H10.9998ZM11.9998 19C13.9331 19 15.5831 18.3167 16.9498 16.95C18.3165 15.5834 18.9998 13.9334 18.9998 12C18.9998 10.0667 18.3165 8.41672 16.9498 7.05005C15.5831 5.68338 13.9331 5.00005 11.9998 5.00005C10.0665 5.00005 8.41647 5.68338 7.0498 7.05005C5.68314 8.41672 4.9998 10.0667 4.9998 12C4.9998 13.9334 5.68314 15.5834 7.0498 16.95C8.41647 18.3167 10.0665 19 11.9998 19ZM11.9998 16C10.8998 16 9.95814 15.6084 9.1748 14.825C8.39147 14.0417 7.9998 13.1 7.9998 12C7.9998 10.9 8.39147 9.95838 9.1748 9.17505C9.95814 8.39172 10.8998 8.00005 11.9998 8.00005C13.0998 8.00005 14.0415 8.39172 14.8248 9.17505C15.6081 9.95838 15.9998 10.9 15.9998 12C15.9998 13.1 15.6081 14.0417 14.8248 14.825C14.0415 15.6084 13.0998 16 11.9998 16ZM11.9998 14C12.5498 14 13.0206 13.8042 13.4123 13.4125C13.804 13.0209 13.9998 12.55 13.9998 12C13.9998 11.45 13.804 10.9792 13.4123 10.5875C13.0206 10.1959 12.5498 10 11.9998 10C11.4498 10 10.979 10.1959 10.5873 10.5875C10.1956 10.9792 9.9998 11.45 9.9998 12C9.9998 12.55 10.1956 13.0209 10.5873 13.4125C10.979 13.8042 11.4498 14 11.9998 14Z" fill="currentColor"/>
-        </svg>
-      </adb-icon-button>
-      @if (geolocationDenied()) {
-        <span id="geolocation-denied-tooltip" role="tooltip" class="toolbar-tooltip">
-          {{ 'mapToolbar.geolocationDeniedTooltip' | translate }}
-        </span>
-      }
-    </div>
-    <adb-icon-button variant="secondary" [attr.data-action]="toolbarActions.FULLSCREEN" (click)="onButtonClick(toolbarActions.FULLSCREEN)" [attr.aria-label]="'mapToolbar.fullscreenAriaLabel' | translate">
-      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-        <path d="M5 19V13H7V17H11V19H5ZM17 11V7H13V5H19V11H17Z" fill="currentColor"/>
-      </svg>
-    </adb-icon-button>
-    <adb-icon-button variant="secondary" [attr.data-action]="toolbarActions.ZOOM_IN" (click)="onButtonClick(toolbarActions.ZOOM_IN)" [attr.aria-label]="'mapToolbar.zoomInAriaLabel' | translate">
-      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-        <path d="M11 13H5V11H11V5H13V11H19V13H13V19H11V13Z" fill="currentColor"/>
-      </svg>
-    </adb-icon-button>
-    <adb-icon-button variant="secondary" [attr.data-action]="toolbarActions.ZOOM_OUT" (click)="onButtonClick(toolbarActions.ZOOM_OUT)" [attr.aria-label]="'mapToolbar.zoomOutAriaLabel' | translate">
-      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-        <path d="M5 11H19V13H5V11Z" fill="currentColor"/>
+        <path
+          fill-rule="evenodd"
+          clip-rule="evenodd"
+          d="M15 19.5V22H21V16H18.7208L16 7.83772V2H10V6.9L7.3 10H3V16H8L15 19.5ZM13.9459 8H11.7L9 11.1V14.25L15 17.25V16H16.6126L13.9459 8ZM14 6H12V4H14V6ZM7 14H5V12H7V14ZM19 20H17V18H19V20Z"
+          fill="currentColor"
+        />
       </svg>
     </adb-icon-button>
   </div>

--- a/Artskart3.WebApp/src/app/shared/components/map.component/map-toolbar/map-toolbar.component.spec.ts
+++ b/Artskart3.WebApp/src/app/shared/components/map.component/map-toolbar/map-toolbar.component.spec.ts
@@ -2,29 +2,13 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { provideTranslateService } from '@ngx-translate/core';
 
-import { NbicMapComponent } from '@artsdatabanken/nbic-map-component';
 import { MapToolbarComponent } from './map-toolbar.component';
-import { ToolbarAction } from './map-toolbar.constants';
 
 describe('MapToolbarComponent', () => {
   let component: MapToolbarComponent;
   let fixture: ComponentFixture<MapToolbarComponent>;
 
-  const createMockPermissionStatus = (state: PermissionState) => ({
-    state,
-    onchange: null as (() => void) | null,
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn(),
-    dispatchEvent: vi.fn(),
-  });
-
   beforeEach(async () => {
-    Object.defineProperty(navigator, 'permissions', {
-      value: { query: vi.fn() },
-      writable: true,
-      configurable: true,
-    });
-
     await TestBed.configureTestingModule({
       imports: [MapToolbarComponent],
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
@@ -32,128 +16,10 @@ describe('MapToolbarComponent', () => {
     }).compileComponents();
   });
 
-  it('should create', async () => {
-    vi.mocked(navigator.permissions.query).mockResolvedValue(
-      createMockPermissionStatus('prompt') as unknown as PermissionStatus,
-    );
+  it('should create', () => {
     fixture = TestBed.createComponent(MapToolbarComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
-    await fixture.whenStable();
     expect(component).toBeTruthy();
-  });
-
-  describe('geolocation denied', () => {
-    it('should disable the geolocation button when permission is denied', async () => {
-      const mockPermissionStatus = createMockPermissionStatus('denied');
-
-      vi.mocked(navigator.permissions.query).mockResolvedValue(
-        mockPermissionStatus as unknown as PermissionStatus,
-      );
-
-      fixture = TestBed.createComponent(MapToolbarComponent);
-      component = fixture.componentInstance;
-      fixture.detectChanges();
-      await fixture.whenStable();
-      fixture.detectChanges();
-
-      const button = fixture.nativeElement.querySelector(
-        `[data-action="${ToolbarAction.GEOLOCATION}"]`,
-      );
-
-      expect(button).toBeTruthy();
-      expect(button.disabled).toBe(true);
-
-      expect(button.getAttribute('aria-describedby')).toBe('geolocation-denied-tooltip');
-      const tooltip = fixture.nativeElement.querySelector('#geolocation-denied-tooltip');
-      expect(tooltip).toBeTruthy();
-      expect(tooltip.getAttribute('role')).toBe('tooltip');
-      expect(tooltip.textContent.trim()).toBe('mapToolbar.geolocationDeniedTooltip');
-    });
-
-    it('should not disable the geolocation button when permission is granted', async () => {
-      const mockPermissionStatus = createMockPermissionStatus('granted');
-
-      vi.mocked(navigator.permissions.query).mockResolvedValue(
-        mockPermissionStatus as unknown as PermissionStatus,
-      );
-
-      fixture = TestBed.createComponent(MapToolbarComponent);
-      component = fixture.componentInstance;
-      fixture.detectChanges();
-      await fixture.whenStable();
-
-      const button = fixture.nativeElement.querySelector(
-        `[data-action="${ToolbarAction.GEOLOCATION}"]`,
-      );
-
-      expect(button).toBeTruthy();
-      expect(button.disabled).toBe(false);
-    });
-
-    it('should disable button when geolocation permission is denied on click', async () => {
-      const mockPermissionStatus = createMockPermissionStatus('prompt');
-
-      vi.mocked(navigator.permissions.query).mockResolvedValue(
-        mockPermissionStatus as unknown as PermissionStatus,
-      );
-
-      Object.defineProperty(navigator, 'geolocation', {
-        value: {
-          getCurrentPosition: (_success: PositionCallback, error: PositionErrorCallback) => {
-            error({
-              code: 1, // PERMISSION_DENIED
-              message: 'User denied',
-            } as GeolocationPositionError);
-          },
-        },
-        writable: true,
-        configurable: true,
-      });
-
-      const mockMap = {
-        zoomToGeolocation: vi.fn().mockResolvedValue(true),
-      } as unknown as NbicMapComponent;
-
-      fixture = TestBed.createComponent(MapToolbarComponent);
-      component = fixture.componentInstance;
-      component.map = mockMap;
-      fixture.detectChanges();
-      await fixture.whenStable();
-
-      component.onButtonClick(ToolbarAction.GEOLOCATION);
-      await fixture.whenStable();
-      fixture.detectChanges();
-
-      const button = fixture.nativeElement.querySelector(
-        `[data-action="${ToolbarAction.GEOLOCATION}"]`,
-      );
-
-      expect(button.disabled).toBe(true);
-    });
-
-    it('should update disabled state when permission changes', async () => {
-      const mockPermissionStatus = createMockPermissionStatus('prompt');
-
-      vi.mocked(navigator.permissions.query).mockResolvedValue(
-        mockPermissionStatus as unknown as PermissionStatus,
-      );
-
-      fixture = TestBed.createComponent(MapToolbarComponent);
-      component = fixture.componentInstance;
-      fixture.detectChanges();
-      await fixture.whenStable();
-
-      const button = fixture.nativeElement.querySelector(
-        `[data-action="${ToolbarAction.GEOLOCATION}"]`,
-      );
-      expect(button.disabled).toBe(false);
-
-      mockPermissionStatus.state = 'denied';
-      mockPermissionStatus.onchange!();
-      fixture.detectChanges();
-
-      expect(button.disabled).toBe(true);
-    });
   });
 });

--- a/Artskart3.WebApp/src/app/shared/components/map.component/map-toolbar/map-toolbar.component.ts
+++ b/Artskart3.WebApp/src/app/shared/components/map.component/map-toolbar/map-toolbar.component.ts
@@ -1,7 +1,6 @@
-import { Component, Output, EventEmitter, Input, CUSTOM_ELEMENTS_SCHEMA, inject, signal, OnInit, OnDestroy } from '@angular/core';
+import { Component, CUSTOM_ELEMENTS_SCHEMA, inject, output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
-import { NbicMapComponent } from '@artsdatabanken/nbic-map-component';
 import { ToolbarAction } from './map-toolbar.constants';
 import { MapTypeSelectorComponent } from './map-type-selector/map-type-selector.component';
 import { LoggingService } from '@shared/logging.service';
@@ -10,27 +9,18 @@ type ActionHandler = () => void;
 
 @Component({
   selector: 'app-map-toolbar',
-  standalone: true,
   imports: [CommonModule, TranslateModule, MapTypeSelectorComponent],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
   templateUrl: './map-toolbar.component.html',
   styleUrl: './map-toolbar.component.css',
 })
-export class MapToolbarComponent implements OnInit, OnDestroy {
-  @Input() public map!: NbicMapComponent;
-  @Output() iconClick = new EventEmitter<string>();
+export class MapToolbarComponent {
+  readonly iconClick = output<string>();
 
   private readonly logger = inject(LoggingService);
   protected readonly toolbarActions = ToolbarAction;
-  protected readonly geolocationDenied = signal(false);
-
-  private permissionStatus: PermissionStatus | null = null;
 
   private readonly actionHandlers: Record<ToolbarAction, ActionHandler> = {
-    [ToolbarAction.ZOOM_IN]: () => this.zoomIn(),
-    [ToolbarAction.ZOOM_OUT]: () => this.zoomOut(),
-    [ToolbarAction.GEOLOCATION]: () => this.geolocation(),
-    [ToolbarAction.FULLSCREEN]: () => this.toggleFullscreen(),
     [ToolbarAction.MAP]: () => this.emitAction(ToolbarAction.MAP),
     [ToolbarAction.LAYERS]: () => this.emitAction(ToolbarAction.LAYERS),
     [ToolbarAction.FILTER]: () => this.emitAction(ToolbarAction.FILTER),
@@ -43,37 +33,6 @@ export class MapToolbarComponent implements OnInit, OnDestroy {
 
   onMapTypeSelected(layerId: string): void {
     this.iconClick.emit(`map-type:${layerId}`);
-  }
-
-  ngOnInit(): void {
-    this.queryGeolocationPermission();
-  }
-
-  ngOnDestroy(): void {
-    if (this.permissionStatus) {
-      this.permissionStatus.onchange = null;
-    }
-  }
-
-  private queryGeolocationPermission(): void {
-    if (!navigator.permissions) return;
-
-    navigator.permissions
-      .query({ name: 'geolocation' })
-      .then((status) => {
-        this.permissionStatus = status;
-
-        if (status.state === 'denied') {
-          this.geolocationDenied.set(true);
-        }
-
-        status.onchange = () => {
-          this.geolocationDenied.set(status.state === 'denied');
-        };
-      })
-      .catch(() => {
-        // Permissions API not supported for geolocation in this browser
-      });
   }
 
   private handleIconClick(actionName: string): void {
@@ -91,59 +50,7 @@ export class MapToolbarComponent implements OnInit, OnDestroy {
     }
   }
 
-  private zoomIn(): void {
-    if (!this.map) return;
-    const { zoom } = this.map.getCamera();
-    this.map.setZoom(zoom + 1);
-  }
-
-  private zoomOut(): void {
-    if (!this.map) return;
-    const { zoom } = this.map.getCamera();
-    this.map.setZoom(zoom - 1);
-  }
-
-  private async geolocation(): Promise<void> {
-    if (!this.map) return;
-
-    const permissionGranted = await new Promise<boolean>((resolve) => {
-      navigator.geolocation.getCurrentPosition(
-        () => resolve(true),
-        (error) => {
-          if (error.code === 1) {
-            // PERMISSION_DENIED
-            resolve(false);
-          } else {
-            // Other errors (timeout, position unavailable) — still allowed
-            resolve(true);
-          }
-        },
-        { timeout: 5000, maximumAge: Infinity },
-      );
-    });
-
-    if (!permissionGranted) {
-      this.geolocationDenied.set(true);
-      return;
-    }
-
-    try {
-      await this.map.zoomToGeolocation(14);
-    } catch {
-      // Map zoom failed but permission was granted — don't disable button
-    }
-  }
-
   private emitAction(action: ToolbarAction): void {
     this.iconClick.emit(action);
-  }
-
-  private toggleFullscreen(): void {
-    if (!this.map) return;
-    if (!document.fullscreenElement) {
-      this.map.enterFullScreen();
-    } else {
-      this.map.leaveFullScreen();
-    }
   }
 }

--- a/Artskart3.WebApp/src/app/shared/components/map.component/map-toolbar/map-toolbar.constants.ts
+++ b/Artskart3.WebApp/src/app/shared/components/map.component/map-toolbar/map-toolbar.constants.ts
@@ -1,9 +1,5 @@
 
 export enum ToolbarAction {
-  ZOOM_IN = 'plus',
-  ZOOM_OUT = 'minus',
-  GEOLOCATION = 'posisjon',
-  FULLSCREEN = 'expand',
   MAP = 'kart',
   LAYERS = 'layers',
   FILTER = 'filter',

--- a/Artskart3.WebApp/src/app/shared/components/map.component/map.component.css
+++ b/Artskart3.WebApp/src/app/shared/components/map.component/map.component.css
@@ -15,6 +15,119 @@
   width: 100%;
 }
 
+/* Adopted OL controls — shared button styles */
+/* ::ng-deep is deprecated but required here since OL controls render outside Angular's view encapsulation */
+
+::ng-deep .artskart-zoom,
+::ng-deep .artskart-fullscreen,
+::ng-deep .artskart-geolocation {
+  background: transparent;
+  border-radius: 0;
+}
+
+::ng-deep .artskart-zoom button,
+::ng-deep .artskart-fullscreen button,
+::ng-deep .artskart-geolocation button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  margin: 0;
+  border: none;
+  border-radius: 50%;
+  background: var(--adb-surface-primary, #fff);
+  color: var(--adb-text-accent, #005a71);
+  cursor: pointer;
+  box-shadow: inset 0 0 0 2px var(--adb-border-accent, #005a71);
+  padding: 0;
+  transition: box-shadow 0.15s, background-color 0.15s, color 0.15s;
+}
+
+::ng-deep .artskart-zoom button:hover,
+::ng-deep .artskart-fullscreen button:hover,
+::ng-deep .artskart-geolocation button:hover {
+  background: var(--adb-surface-primary, #fff);
+  color: var(--adb-text-hover, #004557);
+  box-shadow: inset 0 0 0 4px var(--adb-border-hover, #004557);
+  outline: none;
+}
+
+::ng-deep .artskart-zoom button:active,
+::ng-deep .artskart-fullscreen button:active,
+::ng-deep .artskart-geolocation button:active {
+  background: var(--adb-surface-accent, #005a71);
+  color: var(--adb-text-invert, #fff);
+}
+
+::ng-deep .artskart-zoom button:focus-visible,
+::ng-deep .artskart-fullscreen button:focus-visible,
+::ng-deep .artskart-geolocation button:focus-visible {
+  color: var(--adb-text-hover, #004557);
+  box-shadow: inset 0 0 0 4px var(--adb-border-hover, #004557);
+  outline: 2px solid var(--adb-border-accent, #005a71);
+  outline-offset: 2px;
+}
+
+::ng-deep .artskart-geolocation button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+::ng-deep .artskart-geolocation button:disabled:hover {
+  box-shadow: inset 0 0 0 2px var(--adb-border-accent, #005a71);
+  color: var(--adb-text-accent, #005a71);
+}
+
+/* Adopted OL controls — positioning */
+
+::ng-deep .artskart-zoom {
+  position: absolute;
+  bottom: 40px;
+  right: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+::ng-deep .artskart-fullscreen {
+  position: absolute;
+  bottom: 136px;
+  right: 12px;
+}
+
+::ng-deep .artskart-geolocation {
+  position: absolute;
+  bottom: 184px;
+  right: 12px;
+}
+
+::ng-deep .artskart-geolocation-wrapper {
+  position: relative;
+}
+
+::ng-deep .artskart-geolocation-tooltip {
+  display: none;
+  position: absolute;
+  right: calc(100% + 8px);
+  top: 50%;
+  transform: translateY(-50%);
+  background: #333;
+  color: #fff;
+  font-size: 13px;
+  line-height: 1.4;
+  padding: 6px 10px;
+  border-radius: 4px;
+  white-space: nowrap;
+  pointer-events: none;
+  z-index: 200;
+}
+
+::ng-deep .artskart-geolocation-wrapper:hover .artskart-geolocation-tooltip--visible,
+::ng-deep .artskart-geolocation-wrapper:focus-within .artskart-geolocation-tooltip--visible {
+  display: block;
+}
+
 .marker-tooltip {
   position: fixed;
   background: white;

--- a/Artskart3.WebApp/src/app/shared/components/map.component/map.component.html
+++ b/Artskart3.WebApp/src/app/shared/components/map.component/map.component.html
@@ -1,4 +1,4 @@
 <div class="map-container">
   <div #mapEl class="map"></div>
-  <app-map-toolbar [map]="map!" (iconClick)="onIconClick($event)"></app-map-toolbar>
+  <app-map-toolbar (iconClick)="onIconClick($event)"></app-map-toolbar>
 </div>

--- a/Artskart3.WebApp/src/app/shared/components/map.component/map.component.ts
+++ b/Artskart3.WebApp/src/app/shared/components/map.component/map.component.ts
@@ -30,6 +30,10 @@ import { ImageTile } from 'ol';
 import { ApiZoomLevel } from './map.types';
 import { FilterStateService } from '../../services/filter-state/filter-state.service';
 import { AreaService } from '../../services/area/area.service';
+import { ArtskartZoomControl } from './controls/zoom.control';
+import { ArtskartFullscreenControl } from './controls/fullscreen.control';
+import { createGeolocationControl, GeolocationMapControl } from './controls/geolocation.control';
+import { TranslateService } from '@ngx-translate/core';
 
 @Component({
   selector: 'app-map',
@@ -48,6 +52,9 @@ export class MapComponent implements AfterViewInit, OnDestroy {
   private readonly LOCATIONS_LAYER_ID = 'area-markers-locations';
 
   public map!: NbicMapComponent;
+  private zoomControl?: ArtskartZoomControl;
+  private fullscreenControl?: ArtskartFullscreenControl;
+  private geolocationControl?: GeolocationMapControl;
   private areaDataCacheByApiZoom = new Map<number, AreaMarkerDto[]>();
   private mapReady = false;
 
@@ -59,6 +66,7 @@ export class MapComponent implements AfterViewInit, OnDestroy {
   private readonly logger = inject(LoggingService);
   private readonly filterState = inject(FilterStateService);
   private readonly areaService = inject(AreaService);
+  private readonly translate = inject(TranslateService);
 
   private readonly locationFilter = computed<LocationSearchFilter>(
     () => {
@@ -120,6 +128,8 @@ export class MapComponent implements AfterViewInit, OnDestroy {
       });
 
       this.setupBaseMapLayers();
+      this.adoptMapControls();
+      this.listenForLanguageChanges();
       this.map.on(MapEvents.Ready, () => this.onMapReady());
     } catch (error: unknown) {
       this.logger.error('Failed to initialize map:', 'MapComponent', error);
@@ -150,6 +160,64 @@ export class MapComponent implements AfterViewInit, OnDestroy {
       };
     }
     this.map.addLayer(nib);
+  }
+
+  private adoptMapControls(): void {
+    this.adoptZoomControl();
+    this.adoptFullscreenControl();
+    this.adoptGeolocationControl();
+    // TODO: Polygon draw controls should be adopted here using nbic-map-component's draw API
+    // (map.startDrawing, map.stopDrawing, map.undoLastPoint, map.finishCurrent, etc.)
+    // See Artsobservasjoner3's shared-map.component.ts for reference implementation.
+  }
+
+  private adoptZoomControl(): void {
+    if (!this.map) return;
+    this.zoomControl = new ArtskartZoomControl({
+      zoomInTipLabel: this.translate.instant('mapToolbar.zoomInAriaLabel'),
+      zoomOutTipLabel: this.translate.instant('mapToolbar.zoomOutAriaLabel'),
+    });
+    this.map.adoptControl(this.zoomControl, 'zoom');
+  }
+
+  private adoptFullscreenControl(): void {
+    if (!this.map) return;
+    this.fullscreenControl = new ArtskartFullscreenControl({
+      tipLabel: this.translate.instant('mapToolbar.fullscreenAriaLabel'),
+    });
+    this.map.adoptControl(this.fullscreenControl, 'fullscreen');
+  }
+
+  private adoptGeolocationControl(): void {
+    if (!this.map) return;
+    this.geolocationControl = createGeolocationControl(
+      {
+        tipLabel: this.translate.instant('mapToolbar.geolocationAriaLabel'),
+        deniedTooltip: this.translate.instant('mapToolbar.geolocationDeniedTooltip'),
+      },
+      {
+        onClick: () => this.map.zoomToGeolocation(14),
+      },
+    );
+    this.map.adoptControl(this.geolocationControl, 'geolocation');
+  }
+
+  private listenForLanguageChanges(): void {
+    this.translate.onLangChange
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        this.zoomControl?.updateLabels({
+          zoomInTipLabel: this.translate.instant('mapToolbar.zoomInAriaLabel'),
+          zoomOutTipLabel: this.translate.instant('mapToolbar.zoomOutAriaLabel'),
+        });
+        this.fullscreenControl?.updateLabels({
+          tipLabel: this.translate.instant('mapToolbar.fullscreenAriaLabel'),
+        });
+        this.geolocationControl?.updateLabels({
+          tipLabel: this.translate.instant('mapToolbar.geolocationAriaLabel'),
+          deniedTooltip: this.translate.instant('mapToolbar.geolocationDeniedTooltip'),
+        });
+      });
   }
 
   private onMapReady(): void {
@@ -280,6 +348,7 @@ export class MapComponent implements AfterViewInit, OnDestroy {
   private cleanup(): void {
     this.destroy$.next();
     this.destroy$.complete();
+    this.geolocationControl?.dispose();
     this.areaDataCacheByApiZoom.clear();
     this.map?.destroy?.();
   }


### PR DESCRIPTION
Move zoom, fullscreen, and geolocation controls from the Angular toolbar overlay to native OpenLayers controls using nbic-map-component's adoptControl API. This aligns with how the library is designed to be used and how Artsobservasjoner3 handles map controls.

Controls are now managed directly by the OL map instance, eliminating the need for pointer-events hacks and z-index layering that the overlay approach required.

The map-type-selector remains as an Angular overlay component because it uses design system web components (adb-radio-group, adb-radio) with Angular template binding and i18n — capabilities that don't translate well to imperative OL control DOM. Complex interactive panels (dropdowns, layer selectors, filters) are better served by Angular's component model, while simple map buttons are natural OL controls.

Key decisions:
- Subclass OL Zoom/FullScreen to add updateLabels() for i18n support
- Geolocation is a custom OL Control with built-in permission handling
- Language changes update labels in-place (no control re-creation)
- Styling matches adb-icon-button[variant="secondary"] via CSS variables