### PR TITLE
fixed pagination bug when we have less than 4 pages of data

### DIFF
--- a/Artskart3.Api/Controllers/SearchController.cs
+++ b/Artskart3.Api/Controllers/SearchController.cs
@@ -1,9 +1,11 @@
 using Artskart3.Api.Filters;
+using Artskart3.Core.Application.Configuration;
 using Artskart3.Core.Application.DTOs;
 using Artskart3.Core.Application.Services.Interfaces;
 using Artskart3.Core.Constants;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 
 namespace Artskart3.Api.Controllers;
 
@@ -15,12 +17,14 @@ public class SearchController : ControllerBase
     private readonly ISearchService _searchService;
     private readonly ISpeciesService _speciesService;
     private readonly ILogger<SearchController> _logger;
+    private readonly PaginationOptions _paginationOptions;
 
-    public SearchController(ISearchService searchService, ISpeciesService speciesService, ILogger<SearchController> logger)
+    public SearchController(ISearchService searchService, ISpeciesService speciesService, ILogger<SearchController> logger, IOptions<PaginationOptions> paginationOptions)
     {
         _searchService = searchService ?? throw new ArgumentNullException(nameof(searchService));
         _speciesService = speciesService ?? throw new ArgumentNullException(nameof(speciesService));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _paginationOptions = paginationOptions?.Value ?? throw new ArgumentNullException(nameof(paginationOptions));
     }
 
     /// <summary>
@@ -109,12 +113,14 @@ public class SearchController : ControllerBase
                 var allItems = await _searchService.GetObservationsAsync(filter, cancellationToken);
                 var resultsPerPage = filter.ResultsPerPage!.Value;
                 var pageNumber = filter.PageNumber!.Value;
+                var lookaheadLimit = resultsPerPage * _paginationOptions.LookaheadMultiplier;
                 var pagedResult = new PagedObservationResponseDto
                 {
                     Items = allItems.Take(resultsPerPage),
                     PageNumber = pageNumber,
                     ResultsPerPage = resultsPerPage,
-                    LookaheadCount = Math.Max(0, (allItems.Count + resultsPerPage - 1) / resultsPerPage - 1)
+                    LookaheadCount = Math.Max(0, (allItems.Count + resultsPerPage - 1) / resultsPerPage - 1),
+                    HasMorePages = allItems.Count >= lookaheadLimit
                 };
 
                 return Ok(pagedResult);

--- a/Artskart3.Core/Application/DTOs/PagedObservationResponseDto.cs
+++ b/Artskart3.Core/Application/DTOs/PagedObservationResponseDto.cs
@@ -9,4 +9,6 @@ public class PagedObservationResponseDto
     public int ResultsPerPage { get; set; }
 
     public int LookaheadCount { get; set; }
+
+    public bool HasMorePages { get; set; }
 }

--- a/Artskart3.Tests.Unit/SearchControllerAdditionalTests.cs
+++ b/Artskart3.Tests.Unit/SearchControllerAdditionalTests.cs
@@ -1,9 +1,11 @@
 using Artskart3.Api.Controllers;
+using Artskart3.Core.Application.Configuration;
 using Artskart3.Core.Application.DTOs;
 using Artskart3.Core.Application.Services.Interfaces;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
 
 namespace Artskart3.Tests.Unit;
@@ -17,7 +19,7 @@ public class SearchControllerAdditionalTests
     [Fact]
     public void Constructor_ThrowsArgumentNullException_WhenSearchServiceIsNull()
     {
-        var act = () => new SearchController(null!, _speciesServiceMock.Object, _loggerMock.Object);
+        var act = () => new SearchController(null!, _speciesServiceMock.Object, _loggerMock.Object, Options.Create(new PaginationOptions()));
 
         act.Should().Throw<ArgumentNullException>()
             .WithParameterName("searchService");
@@ -26,7 +28,7 @@ public class SearchControllerAdditionalTests
     [Fact]
     public void Constructor_ThrowsArgumentNullException_WhenSpeciesServiceIsNull()
     {
-        var act = () => new SearchController(_serviceMock.Object, null!, _loggerMock.Object);
+        var act = () => new SearchController(_serviceMock.Object, null!, _loggerMock.Object, Options.Create(new PaginationOptions()));
 
         act.Should().Throw<ArgumentNullException>()
             .WithParameterName("speciesService");
@@ -35,7 +37,7 @@ public class SearchControllerAdditionalTests
     [Fact]
     public void Constructor_ThrowsArgumentNullException_WhenLoggerIsNull()
     {
-        var act = () => new SearchController(_serviceMock.Object, _speciesServiceMock.Object, null!);
+        var act = () => new SearchController(_serviceMock.Object, _speciesServiceMock.Object, null!, Options.Create(new PaginationOptions()));
 
         act.Should().Throw<ArgumentNullException>()
             .WithParameterName("logger");
@@ -88,5 +90,5 @@ public class SearchControllerAdditionalTests
             f.CoordinatePrecision.To == 100)), Times.Once);
     }
 
-    private SearchController CreateSut() => new(_serviceMock.Object, _speciesServiceMock.Object, _loggerMock.Object);
+    private SearchController CreateSut() => new(_serviceMock.Object, _speciesServiceMock.Object, _loggerMock.Object, Options.Create(new PaginationOptions()));
 }

--- a/Artskart3.Tests.Unit/SearchControllerObservationTests.cs
+++ b/Artskart3.Tests.Unit/SearchControllerObservationTests.cs
@@ -1,9 +1,11 @@
 using Artskart3.Api.Controllers;
+using Artskart3.Core.Application.Configuration;
 using Artskart3.Core.Application.DTOs;
 using Artskart3.Core.Application.Services.Interfaces;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
 
 namespace Artskart3.Tests.Unit;
@@ -214,11 +216,34 @@ public class SearchControllerObservationTests
         pagedResult.LookaheadCount.Should().Be(expectedLookahead);
     }
 
+    [Theory]
+    [InlineData(40, 10, true)]   // nøyaktig fullt vindu (10 * 4) → kan finnes flere sider
+    [InlineData(39, 10, false)]  // ett under → alle resultater hentet, ingen flere sider
+    [InlineData(0, 10, false)]   // tomt resultat → ingen flere sider
+    [InlineData(100, 25, true)]  // 25 * 4 = 100, fullt vindu → kan finnes flere sider
+    [InlineData(99, 25, false)]  // ett under → ingen flere sider
+    public async Task GetObservations_WithPagination_CalculatesCorrectHasMorePages(
+        int totalItems, int resultsPerPage, bool expectedHasMore)
+    {
+        var sut = CreateSut();
+        var allItems = CreateObservations(totalItems);
+        _serviceMock
+            .Setup(s => s.GetObservationsAsync(It.IsAny<ObservationSearchFilterDto>()))
+            .ReturnsAsync(allItems);
+
+        var filter = new ObservationSearchFilterDto { PageNumber = 1, ResultsPerPage = resultsPerPage };
+        var result = await sut.GetObservations(filter);
+
+        var pagedResult = result.Result.Should().BeOfType<OkObjectResult>().Subject
+            .Value.Should().BeOfType<PagedObservationResponseDto>().Subject;
+        pagedResult.HasMorePages.Should().Be(expectedHasMore);
+    }
+
     // -----------------------------------------------------------------------
     // Helpers
     // -----------------------------------------------------------------------
 
-    private SearchController CreateSut() => new(_serviceMock.Object, _speciesServiceMock.Object, _loggerMock.Object);
+    private SearchController CreateSut() => new(_serviceMock.Object, _speciesServiceMock.Object, _loggerMock.Object, Options.Create(new PaginationOptions()));
 
     private static List<ObservationDto> CreateObservations(int count) =>
         CreateObservationsFromOffset(1, count);

--- a/Artskart3.Tests.Unit/SearchControllerSpeciesTests.cs
+++ b/Artskart3.Tests.Unit/SearchControllerSpeciesTests.cs
@@ -1,9 +1,11 @@
 using Artskart3.Api.Controllers;
+using Artskart3.Core.Application.Configuration;
 using Artskart3.Core.Application.DTOs;
 using Artskart3.Core.Application.Services.Interfaces;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
 
 namespace Artskart3.Tests.Unit;
@@ -14,7 +16,7 @@ public class SearchControllerSpeciesTests
     private readonly Mock<ISpeciesService> _speciesServiceMock = new();
     private readonly Mock<ILogger<SearchController>> _loggerMock = new();
 
-    private SearchController CreateSut() => new(_searchServiceMock.Object, _speciesServiceMock.Object, _loggerMock.Object);
+    private SearchController CreateSut() => new(_searchServiceMock.Object, _speciesServiceMock.Object, _loggerMock.Object, Options.Create(new PaginationOptions()));
 
     // -----------------------------------------------------------------------
     // Validering

--- a/Artskart3.Tests.Unit/SearchControllerTests.cs
+++ b/Artskart3.Tests.Unit/SearchControllerTests.cs
@@ -1,9 +1,11 @@
 using Artskart3.Api.Controllers;
+using Artskart3.Core.Application.Configuration;
 using Artskart3.Core.Application.DTOs;
 using Artskart3.Core.Application.Services.Interfaces;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
 
 namespace Artskart3.Tests.Unit;
@@ -20,7 +22,7 @@ public class SearchControllerTests
         _serviceMock = new Mock<ISearchService>();
         _speciesServiceMock = new Mock<ISpeciesService>();
         _loggerMock = new Mock<ILogger<SearchController>>();
-        _sut = new SearchController(_serviceMock.Object, _speciesServiceMock.Object, _loggerMock.Object);
+        _sut = new SearchController(_serviceMock.Object, _speciesServiceMock.Object, _loggerMock.Object, Options.Create(new PaginationOptions()));
     }
 
     // -----------------------------------------------------------------------

--- a/Artskart3.WebApp/src/app/shared/components/list-view/list-view.component.html
+++ b/Artskart3.WebApp/src/app/shared/components/list-view/list-view.component.html
@@ -50,6 +50,7 @@
       <adb-pagination
         class="pagination"
         [attr.current-page]="pageNumber()"
+        [attr.total-pages]="!hasMorePages() ? totalVisiblePages() : null"
         [attr.visible-pages]="4"
         [attr.has-more-pages]="hasMorePages() || null"
         [attr.page-size-options]="pageSizeOptions.join(',')"

--- a/Artskart3.WebApp/src/app/shared/components/list-view/list-view.component.ts
+++ b/Artskart3.WebApp/src/app/shared/components/list-view/list-view.component.ts
@@ -155,7 +155,7 @@ export class ListViewComponent {
   readonly hasMorePages = computed(() => {
     const response = this.observationsResource.value();
     if (!response) return false;
-    return (response.lookaheadCount ?? 0) > 0;
+    return response.hasMorePages ?? false;
   });
 
   onPageChange(page: number) {

--- a/Artskart3.WebApp/src/app/shared/types/api.generated.ts
+++ b/Artskart3.WebApp/src/app/shared/types/api.generated.ts
@@ -1003,6 +1003,7 @@ export interface components {
             resultsPerPage?: number;
             /** Format: int32 */
             lookaheadCount?: number;
+            hasMorePages?: boolean;
         };
         PeriodDto: {
             /** Format: int32 */


### PR DESCRIPTION
Bugfix:
Når anltall sider var mindre enn 4 (hardkodet) så viste pagineringen 4 sider med ... helt til man klikket på den siste som har data.
Kan testes med  artsgruppe "Begerormer" som har 30 funn. Vi har fortsatt en issue med litt rar funkjsonalitet på pagineringskomponenten, men da må vi evt endre i designsystemet så lager en egen task på det.