### PR TITLE
290 minimer data vi sender til frontend

### DIFF
--- a/Artskart3.Api/Controllers/SearchController.cs
+++ b/Artskart3.Api/Controllers/SearchController.cs
@@ -1,5 +1,6 @@
 using Artskart3.Api.Filters;
 using Artskart3.Core.Application.Configuration;
+using Artskart3.Core.Application.Converters;
 using Artskart3.Core.Application.DTOs;
 using Artskart3.Core.Application.Services.Interfaces;
 using Artskart3.Core.Constants;
@@ -64,7 +65,7 @@ public class SearchController : ControllerBase
     /// </summary>
     [HttpPost("Locations")]
     [Produces("application/json")]
-    public async Task<ActionResult<string>> GetObservationLocations([FromBody] LocationSearchFilterDto? filter = null, CancellationToken cancellationToken = default)
+    public async Task GetObservationLocations([FromBody] LocationSearchFilterDto? filter = null, CancellationToken cancellationToken = default)
     {
         try
         {
@@ -72,12 +73,15 @@ public class SearchController : ControllerBase
 
             if (!ValidateLocationSearchFilter(filter, out var validationError))
             {
-                // validationError skal aldri være null når en validering feiler
-                return validationError!;
+                await validationError!.ExecuteResultAsync(ControllerContext);
+                return;
             }
-            var result = await _searchService.GetLocationsAsync(filter, cancellationToken);
+
+            var locations = await _searchService.GetLocationsAsync(filter, cancellationToken);
             _logger.LogInformation("Retrieved observation location data for maxResults: {MaxResults}", filter.MaxResults);
-            return Content(result, "application/json");
+
+            Response.ContentType = "application/json";
+            await GeoJsonConverter.WriteLocationsToStreamAsync(Response.Body, locations, filter.Epsg);
         }
         catch (Exception ex)
         {

--- a/Artskart3.Core/Application/Converters/GeoJsonConverter.cs
+++ b/Artskart3.Core/Application/Converters/GeoJsonConverter.cs
@@ -11,10 +11,9 @@ public static class GeoJsonConverter
     /// <summary>
     /// Serialiserer lokasjoner til kompakt JSON-format: { epsg, locations: [[id, lon, lat, count], ...] }
     /// </summary>
-    public static async Task<string> LocationsToCompactJson(
-        IAsyncEnumerable<LocationModel> locations,
-        int? targetEpsg = null,
-        CancellationToken cancellationToken = default)
+    public static string LocationsToCompactJson(
+        List<LocationModel> locations,
+        int? targetEpsg = null)
     {
         int epsgCode = targetEpsg ?? DefaultEpsg;
 
@@ -27,7 +26,7 @@ public static class GeoJsonConverter
         writer.WritePropertyName("locations");
         writer.WriteStartArray();
 
-        await foreach (var location in locations.WithCancellation(cancellationToken))
+        foreach (var location in locations)
         {
             writer.WriteStartArray();
             writer.WriteNumberValue(location.Id);

--- a/Artskart3.Core/Application/Converters/GeoJsonConverter.cs
+++ b/Artskart3.Core/Application/Converters/GeoJsonConverter.cs
@@ -9,7 +9,7 @@ public static class GeoJsonConverter
     private const int DefaultEpsg = 25833;
 
     /// <summary>
-    /// Serialiserer lokasjoner til kompakt JSON-format: { epsg, locations: [[id, lon, lat, count, "locality"], ...] }
+    /// Serialiserer lokasjoner til kompakt JSON-format: { epsg, locations: [[id, lon, lat, count], ...] }
     /// </summary>
     public static async Task<string> LocationsToCompactJson(
         IAsyncEnumerable<LocationModel> locations,
@@ -34,7 +34,6 @@ public static class GeoJsonConverter
             writer.WriteNumberValue(location.Longitude);
             writer.WriteNumberValue(location.Latitude);
             writer.WriteNumberValue(location.ObservationCount);
-            writer.WriteStringValue(location.Locality ?? string.Empty);
             writer.WriteEndArray();
         }
 

--- a/Artskart3.Core/Application/Converters/GeoJsonConverter.cs
+++ b/Artskart3.Core/Application/Converters/GeoJsonConverter.cs
@@ -1,4 +1,3 @@
-using System.Text;
 using System.Text.Json;
 using Artskart3.Core.Domain.BusinessModels;
 
@@ -9,16 +8,16 @@ public static class GeoJsonConverter
     private const int DefaultEpsg = 25833;
 
     /// <summary>
-    /// Serialiserer lokasjoner til kompakt JSON-format: { epsg, locations: [[id, lon, lat, count], ...] }
+    /// Skriver lokasjoner direkte til en strøm i kompakt JSON-format: { epsg, locations: [[id, lon, lat, count], ...] }
     /// </summary>
-    public static string LocationsToCompactJson(
+    public static async Task WriteLocationsToStreamAsync(
+        Stream output,
         List<LocationModel> locations,
         int? targetEpsg = null)
     {
         int epsgCode = targetEpsg ?? DefaultEpsg;
 
-        using var stream = new MemoryStream();
-        using var writer = new Utf8JsonWriter(stream);
+        await using var writer = new Utf8JsonWriter(output, new JsonWriterOptions { SkipValidation = false });
 
         writer.WriteStartObject();
         writer.WriteNumber("epsg", epsgCode);
@@ -38,8 +37,6 @@ public static class GeoJsonConverter
 
         writer.WriteEndArray();
         writer.WriteEndObject();
-        writer.Flush();
-
-        return Encoding.UTF8.GetString(stream.ToArray());
+        await writer.FlushAsync();
     }
 }

--- a/Artskart3.Core/Application/Converters/GeoJsonConverter.cs
+++ b/Artskart3.Core/Application/Converters/GeoJsonConverter.cs
@@ -73,9 +73,6 @@ public static class GeoJsonConverter
         }
         writer.WriteEndObject();
 
-        // Write CRS
-        WriteCrs(writer, epsgCode);
-
         writer.WriteEndObject();
         writer.Flush();
 

--- a/Artskart3.Core/Application/Converters/GeoJsonConverter.cs
+++ b/Artskart3.Core/Application/Converters/GeoJsonConverter.cs
@@ -8,116 +8,40 @@ public static class GeoJsonConverter
 {
     private const int DefaultEpsg = 25833;
 
-    public static async Task<string> LocationsToGeoJson(
+    /// <summary>
+    /// Serialiserer lokasjoner til kompakt JSON-format: { epsg, locations: [[id, lon, lat, count, "locality"], ...] }
+    /// </summary>
+    public static async Task<string> LocationsToCompactJson(
         IAsyncEnumerable<LocationModel> locations,
-        StyleType styleType = StyleType.Unknown,
         int? targetEpsg = null,
         CancellationToken cancellationToken = default)
     {
         int epsgCode = targetEpsg ?? DefaultEpsg;
-        var features = new List<JsonElement>();
+
+        using var stream = new MemoryStream();
+        using var writer = new Utf8JsonWriter(stream);
+
+        writer.WriteStartObject();
+        writer.WriteNumber("epsg", epsgCode);
+
+        writer.WritePropertyName("locations");
+        writer.WriteStartArray();
 
         await foreach (var location in locations.WithCancellation(cancellationToken))
         {
-            var feature = CreateFeatureJson(location, styleType, epsgCode);
-            features.Add(feature);
+            writer.WriteStartArray();
+            writer.WriteNumberValue(location.Id);
+            writer.WriteNumberValue(location.Longitude);
+            writer.WriteNumberValue(location.Latitude);
+            writer.WriteNumberValue(location.ObservationCount);
+            writer.WriteStringValue(location.Locality ?? string.Empty);
+            writer.WriteEndArray();
         }
 
-        var featureCollection = CreateFeatureCollection(features, epsgCode);
-        return featureCollection;
-    }
-
-    private static JsonElement CreateFeatureJson(LocationModel location, StyleType styleType, int epsgCode)
-    {
-        using var stream = new MemoryStream();
-        using var writer = new Utf8JsonWriter(stream);
-
-        writer.WriteStartObject();
-        writer.WriteString("type", "Feature");
-        writer.WriteString("id", location.Id.ToString());
-
-        // Write geometry
-        writer.WritePropertyName("geometry");
-        writer.WriteStartObject();
-        writer.WriteString("type", "Point");
-        writer.WritePropertyName("coordinates");
-        writer.WriteStartArray();
-        writer.WriteNumberValue(location.Longitude);
-        writer.WriteNumberValue(location.Latitude);
         writer.WriteEndArray();
-        writer.WriteEndObject();
-
-        // Write properties
-        writer.WritePropertyName("properties");
-        writer.WriteStartObject();
-        writer.WriteNumber("ObservationCount", location.ObservationCount);
-        writer.WriteString("Locality", location.Locality ?? string.Empty);
-
-        switch (styleType)
-        {
-            case StyleType.Category:
-                writer.WriteNumber("MaxCategory", (int)location.MaxCategory);
-                break;
-            case StyleType.Precision:
-                if (location.CoordinatePrecision.HasValue)
-                {
-                    writer.WriteNumber("Precision", location.CoordinatePrecision.Value);
-                }
-                break;
-            case StyleType.Species:
-                if (location.DominantTaxonId > 0)
-                {
-                    writer.WriteNumber("TaxonId", location.DominantTaxonId);
-                }
-                break;
-        }
-        writer.WriteEndObject();
-
-        writer.WriteEndObject();
-        writer.Flush();
-
-        var json = Encoding.UTF8.GetString(stream.ToArray());
-        using var doc = JsonDocument.Parse(json);
-        return doc.RootElement.Clone();
-    }
-
-    private static string CreateFeatureCollection(List<JsonElement> features, int epsgCode)
-    {
-        using var stream = new MemoryStream();
-        using var writer = new Utf8JsonWriter(stream);
-
-        writer.WriteStartObject();
-        writer.WriteString("type", "FeatureCollection");
-
-        writer.WritePropertyName("features");
-        writer.WriteStartArray();
-        foreach (var feature in features)
-        {
-            feature.WriteTo(writer);
-        }
-        writer.WriteEndArray();
-
-        // Write CRS
-        WriteCrs(writer, epsgCode);
-
         writer.WriteEndObject();
         writer.Flush();
 
         return Encoding.UTF8.GetString(stream.ToArray());
-    }
-
-    private static void WriteCrs(Utf8JsonWriter writer, int epsg)
-    {
-        writer.WritePropertyName("crs");
-        writer.WriteStartObject();
-
-        writer.WritePropertyName("properties");
-        writer.WriteStartObject();
-        writer.WriteString("name", $"EPSG:{epsg}");
-        writer.WriteEndObject();
-
-        writer.WriteString("type", "Name");
-
-        writer.WriteEndObject();
     }
 }

--- a/Artskart3.Core/Application/Services/Implementations/SearchService.cs
+++ b/Artskart3.Core/Application/Services/Implementations/SearchService.cs
@@ -24,8 +24,8 @@ public class SearchService : ISearchService
 
         try
         {
-            var locations = _searchRepository.GetLocationsAsync(filter, cancellationToken);
-            return await GeoJsonConverter.LocationsToCompactJson(locations, filter.Epsg, cancellationToken);
+            var locations = await _searchRepository.GetLocationsAsync(filter, cancellationToken);
+            return GeoJsonConverter.LocationsToCompactJson(locations, filter.Epsg);
         }
         catch (ApplicationException)
         {

--- a/Artskart3.Core/Application/Services/Implementations/SearchService.cs
+++ b/Artskart3.Core/Application/Services/Implementations/SearchService.cs
@@ -1,7 +1,6 @@
 using Artskart3.Core.Application.Converters;
 using Artskart3.Core.Application.DTOs;
 using Artskart3.Core.Application.Services.Interfaces;
-using Artskart3.Core.Domain.BusinessModels;
 using Artskart3.Core.Domain.RepositoryInterfaces;
 using Microsoft.Extensions.Caching.Memory;
 
@@ -26,7 +25,7 @@ public class SearchService : ISearchService
         try
         {
             var locations = _searchRepository.GetLocationsAsync(filter, cancellationToken);
-            return await GeoJsonConverter.LocationsToGeoJson(locations, StyleType.Unknown, filter.Epsg, cancellationToken);
+            return await GeoJsonConverter.LocationsToCompactJson(locations, filter.Epsg, cancellationToken);
         }
         catch (ApplicationException)
         {

--- a/Artskart3.Core/Application/Services/Implementations/SearchService.cs
+++ b/Artskart3.Core/Application/Services/Implementations/SearchService.cs
@@ -1,6 +1,6 @@
-using Artskart3.Core.Application.Converters;
 using Artskart3.Core.Application.DTOs;
 using Artskart3.Core.Application.Services.Interfaces;
+using Artskart3.Core.Domain.BusinessModels;
 using Artskart3.Core.Domain.RepositoryInterfaces;
 using Microsoft.Extensions.Caching.Memory;
 
@@ -18,23 +18,10 @@ public class SearchService : ISearchService
         _cache = cache;
     }
 
-    public async Task<string> GetLocationsAsync(LocationSearchFilterDto? filter = null, CancellationToken cancellationToken = default)
+    public async Task<List<LocationModel>> GetLocationsAsync(LocationSearchFilterDto? filter = null, CancellationToken cancellationToken = default)
     {
-        filter = filter ?? new LocationSearchFilterDto();
-
-        try
-        {
-            var locations = await _searchRepository.GetLocationsAsync(filter, cancellationToken);
-            return GeoJsonConverter.LocationsToCompactJson(locations, filter.Epsg);
-        }
-        catch (ApplicationException)
-        {
-            throw;
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            throw new ApplicationException("Feil ved henting av lokasjoner", ex);
-        }
+        filter ??= new LocationSearchFilterDto();
+        return await _searchRepository.GetLocationsAsync(filter, cancellationToken);
     }
 
     public async Task<List<ObservationDto>> GetObservationsAsync(ObservationSearchFilterDto filter, CancellationToken cancellationToken = default)

--- a/Artskart3.Core/Application/Services/Interfaces/ISearchService.cs
+++ b/Artskart3.Core/Application/Services/Interfaces/ISearchService.cs
@@ -1,11 +1,12 @@
 using Artskart3.Core.Application.DTOs;
+using Artskart3.Core.Domain.BusinessModels;
 
 namespace Artskart3.Core.Application.Services.Interfaces;
 
 public interface ISearchService
 {
     Task<IEnumerable<TaxonDto>> GetTaxonsAsync(string name, int maxCount = 20, CancellationToken cancellationToken = default);
-    Task<string> GetLocationsAsync(LocationSearchFilterDto? filter = null, CancellationToken cancellationToken = default);
+    Task<List<LocationModel>> GetLocationsAsync(LocationSearchFilterDto? filter = null, CancellationToken cancellationToken = default);
     Task<List<ObservationDto>> GetObservationsAsync(ObservationSearchFilterDto filter, CancellationToken cancellationToken = default);
 
     Task<IEnumerable<AreaMarkerDto>> GetAreaMarkersAsync(int zoomLevel, LocationSearchFilterDto? filter = null, CancellationToken cancellationToken = default);

--- a/Artskart3.Core/Domain/BusinessModels/LocationModel.cs
+++ b/Artskart3.Core/Domain/BusinessModels/LocationModel.cs
@@ -1,76 +1,9 @@
-using System.Collections.ObjectModel;
-using System.Text.Json.Serialization;
-using Artskart3.Core.Domain.Enums;
-using NetTopologySuite.Geometries;
-
 namespace Artskart3.Core.Domain.BusinessModels;
 
 public class LocationModel
 {
     public int Id { get; set; }
-    [JsonIgnore]
-    public Geometry? Geometry { get; set; }
-    public string Locality { get; set; } = string.Empty;
-    public int? CoordinatePrecision { get; set; }
     public double Latitude { get; set; }
     public double Longitude { get; set; }
-    public int East { get; set; }
-    public int North { get; set; }
-    public int? TaxonId { get; set; }
-    public Collection<ObservationBaseModel> Observations { get; set; } = new Collection<ObservationBaseModel>();
-    public Collection<AreaModel> Areas { get; set; } = new Collection<AreaModel>();
-    public LocationModel()
-    {
-        Observations = new Collection<ObservationBaseModel>();
-        Areas = new Collection<AreaModel>();
-    }
-
-    private int _observationCount;
-    [JsonIgnore]
-    public int ObservationCount
-    {
-        get
-        {
-            if (Observations.Count != 0)
-            {
-                _observationCount = Observations.Count;
-                return _observationCount;
-            }
-            return _observationCount;
-        }
-
-        set { _observationCount = value; }
-    }
-
-    private Category _maxCategory;
-    [JsonIgnore]
-    public Category MaxCategory
-    {
-        get
-        {
-            if (Observations.Count != 0)
-            {
-                _maxCategory = Category.Unknown;
-                foreach (var observation in Observations)
-                {
-                    if (observation.GetType() == typeof(ObservationModel) || observation.GetType() == typeof(ObservationWithLocationModel))
-                    {
-                        if (((ObservationModel)observation).Category > _maxCategory)
-                        {
-                            _maxCategory = ((ObservationModel)observation).Category;
-                        }
-                    }
-                    else
-                    {
-                        throw new Exception("Cast of observation in Location.MaxCategory failed");
-                    }
-                }
-            }
-            return _maxCategory;
-        }
-
-        set { _maxCategory = value; }
-    }
-
-    public int DominantTaxonId { get; set; }
+    public int ObservationCount { get; set; }
 }

--- a/Artskart3.Core/Domain/RepositoryInterfaces/ISearchRepository.cs
+++ b/Artskart3.Core/Domain/RepositoryInterfaces/ISearchRepository.cs
@@ -6,7 +6,7 @@ namespace Artskart3.Core.Domain.RepositoryInterfaces;
 public interface ISearchRepository
 {
     Task<IEnumerable<TaxonDto>> GetTaxonsAsync(string name, int maxCount = 20, CancellationToken cancellationToken = default);
-    IAsyncEnumerable<LocationModel> GetLocationsAsync(LocationSearchFilterDto? filter = null, CancellationToken cancellationToken = default);
+    Task<List<LocationModel>> GetLocationsAsync(LocationSearchFilterDto? filter = null, CancellationToken cancellationToken = default);
     Task<List<ObservationDto>> GetObservationsAsync(ObservationSearchFilterDto filter, CancellationToken cancellationToken = default);
     Task<IEnumerable<AreaMarkerDto>> GetAreaMarkersAsync(int zoomLevel, LocationSearchFilterDto? filter = null, CancellationToken cancellationToken = default);
 }

--- a/Artskart3.Infrastructure/Persistence/Repositories/SearchRepository.cs
+++ b/Artskart3.Infrastructure/Persistence/Repositories/SearchRepository.cs
@@ -450,7 +450,6 @@ public class SearchRepository : ISearchRepository
             .Select(l => new Location
             {
                 Id = l.Id,
-                Locality = l.Locality,
                 Latitude = l.Latitude,
                 Longitude = l.Longitude,
                 East = l.East,
@@ -476,7 +475,6 @@ public class SearchRepository : ISearchRepository
         return new LocationModel
         {
             Id = location.Id,
-            Locality = location.Locality ?? string.Empty,
             Latitude = location.Latitude ?? 0,
             Longitude = location.Longitude ?? 0,
             East = location.East,

--- a/Artskart3.Infrastructure/Persistence/Repositories/SearchRepository.cs
+++ b/Artskart3.Infrastructure/Persistence/Repositories/SearchRepository.cs
@@ -1,4 +1,3 @@
-using System.Runtime.CompilerServices;
 using Artskart3.Core.Application.Configuration;
 using Artskart3.Core.Application.DTOs;
 using Artskart3.Core.Application.Persistence;
@@ -216,21 +215,10 @@ public class SearchRepository : ISearchRepository
 
 
     /// <summary>
-    /// Retrieves observation locations filtered by taxon group, collection, category, basis of record, and coordinate precision.
-    /// Aggregates observation counts by location, sorted by count descending.
-    /// Returns locations as an async enumerable with UTM Zone 33N coordinates (East/North) and metadata.
+    /// Henter observasjonslokasjoner filtrert etter taksongruppe, kategori, område m.m.
+    /// Aggregerer observasjonsantall per lokasjon, sortert synkende.
     /// </summary>
-    public async IAsyncEnumerable<LocationModel> GetLocationsAsync(LocationSearchFilterDto? filter = null, [EnumeratorCancellation] CancellationToken cancellationToken = default)
-    {
-        var locationModels = await FetchLocationModelsAsync(filter, cancellationToken);
-
-        foreach (var model in locationModels)
-        {
-            yield return model;
-        }
-    }
-
-    private async Task<List<LocationModel>> FetchLocationModelsAsync(LocationSearchFilterDto? filter, CancellationToken cancellationToken = default)
+    public async Task<List<LocationModel>> GetLocationsAsync(LocationSearchFilterDto? filter = null, CancellationToken cancellationToken = default)
     {
         try
         {

--- a/Artskart3.Infrastructure/Persistence/Repositories/SearchRepository.cs
+++ b/Artskart3.Infrastructure/Persistence/Repositories/SearchRepository.cs
@@ -447,6 +447,16 @@ public class SearchRepository : ISearchRepository
         var locationLookup = await _context.Set<Location>()
             .Where(l => locationIds.Contains(l.Id))
             .AsNoTracking()
+            .Select(l => new Location
+            {
+                Id = l.Id,
+                Locality = l.Locality,
+                Latitude = l.Latitude,
+                Longitude = l.Longitude,
+                East = l.East,
+                North = l.North,
+                CoordinatePrecision = l.CoordinatePrecision
+            })
             .ToDictionaryAsync(l => l.Id, cancellationToken);
 
         var locationModels = new List<LocationModel>(aggregatedData.Count);

--- a/Artskart3.Infrastructure/Persistence/Repositories/SearchRepository.cs
+++ b/Artskart3.Infrastructure/Persistence/Repositories/SearchRepository.cs
@@ -236,13 +236,44 @@ public class SearchRepository : ISearchRepository
         {
             filter ??= new LocationSearchFilterDto();
 
-            var query = BuildLocationsQuery(filter);
-            var aggregatedData = await AggregateLocationObservations(query, filter.MaxResults, cancellationToken);
+            var query = _context.Set<Observation>().AsNoTracking();
+            query = ApplyCommonFilters(query, filter);
 
-            if (aggregatedData.Count == 0)
-                return [];
+            // Envelope-filter via Location-tabellen (bruker IX_EastNorth-indeksen)
+            if (filter.Envelope != null)
+            {
+                var minX = (int)filter.Envelope.MinX;
+                var maxX = (int)filter.Envelope.MaxX;
+                var minY = (int)filter.Envelope.MinY;
+                var maxY = (int)filter.Envelope.MaxY;
+                query = query.Where(o => o.Location != null &&
+                    o.Location.East >= minX && o.Location.East <= maxX &&
+                    o.Location.North >= minY && o.Location.North <= maxY);
+            }
 
-            var locationModels = await BuildLocationModels(aggregatedData, cancellationToken);
+            var maxResults = filter.MaxResults > 0 && filter.MaxResults <= SearchConstants.MaxLocationResults
+                ? filter.MaxResults
+                : SearchConstants.DefaultMaxLocations;
+
+            // Én spørring: gruppér på lokasjon, hent koordinater og tell observasjoner
+            var locationModels = await query
+                .Where(o => o.Location != null)
+                .GroupBy(o => new
+                {
+                    LocationId = o.LocationId!.Value,
+                    o.Location!.Latitude,
+                    o.Location!.Longitude
+                })
+                .Select(g => new LocationModel
+                {
+                    Id = g.Key.LocationId,
+                    Latitude = g.Key.Latitude ?? 0,
+                    Longitude = g.Key.Longitude ?? 0,
+                    ObservationCount = g.Count()
+                })
+                .OrderByDescending(x => x.ObservationCount)
+                .Take(maxResults)
+                .ToListAsync(cancellationToken);
 
             _logger.LogInformation("Location search completed successfully. Returned {LocationCount} locations", locationModels.Count);
 
@@ -399,99 +430,6 @@ public class SearchRepository : ISearchRepository
 
         return query;
     }
-    private IQueryable<Observation> BuildLocationsQuery(LocationSearchFilterDto filter)
-    {
-        var query = _context.Set<Observation>().AsNoTracking();
-        query = ApplyCommonFilters(query, filter);
-
-        if (filter.Envelope != null)
-        {
-            var minX = (int)filter.Envelope.MinX;
-            var maxX = (int)filter.Envelope.MaxX;
-            var minY = (int)filter.Envelope.MinY;
-            var maxY = (int)filter.Envelope.MaxY;
-            query = query.Where(o =>
-                o.East >= minX && o.East <= maxX &&
-                o.North >= minY && o.North <= maxY);
-        }
-
-        return query;
-    }
-
-    private async Task<List<AggregatedLocationData>> AggregateLocationObservations(
-        IQueryable<Observation> query,
-        int requestedMaxResults,
-        CancellationToken cancellationToken = default)
-    {
-        var maxResults = requestedMaxResults > 0 && requestedMaxResults <= SearchConstants.MaxLocationResults
-            ? requestedMaxResults
-            : SearchConstants.DefaultMaxLocations;
-
-        return await query
-            .Where(o => o.LocationId != null)
-            .GroupBy(o => o.LocationId!.Value)
-            .Select(g => new AggregatedLocationData
-            {
-                LocationId = g.Key,
-                ObservationCount = g.Count()
-            })
-            .OrderByDescending(x => x.ObservationCount)
-            .Take(maxResults)
-            .ToListAsync(cancellationToken);
-    }
-
-    private async Task<List<LocationModel>> BuildLocationModels(List<AggregatedLocationData> aggregatedData, CancellationToken cancellationToken = default)
-    {
-        var locationIds = aggregatedData.Select(x => x.LocationId).ToList();
-
-        var locationLookup = await _context.Set<Location>()
-            .Where(l => locationIds.Contains(l.Id))
-            .AsNoTracking()
-            .Select(l => new Location
-            {
-                Id = l.Id,
-                Latitude = l.Latitude,
-                Longitude = l.Longitude,
-                East = l.East,
-                North = l.North,
-                CoordinatePrecision = l.CoordinatePrecision
-            })
-            .ToDictionaryAsync(l => l.Id, cancellationToken);
-
-        var locationModels = new List<LocationModel>(aggregatedData.Count);
-
-        foreach (var item in aggregatedData)
-        {
-            if (locationLookup.TryGetValue(item.LocationId, out var location))
-            {
-                locationModels.Add(MapLocationToModel(location, item));
-            }
-        }
-
-        return locationModels;
-    }
-    private static LocationModel MapLocationToModel(Location location, AggregatedLocationData aggregatedData)
-    {
-        return new LocationModel
-        {
-            Id = location.Id,
-            Latitude = location.Latitude ?? 0,
-            Longitude = location.Longitude ?? 0,
-            East = location.East,
-            North = location.North,
-            CoordinatePrecision = location.CoordinatePrecision,
-            TaxonId = aggregatedData.TaxonId,
-            ObservationCount = aggregatedData.ObservationCount
-        };
-    }
-
-    private class AggregatedLocationData
-    {
-        public int LocationId { get; set; }
-        public int? TaxonId { get; set; }
-        public int ObservationCount { get; set; }
-    }
-
     /// <summary>
     /// Henter områdemarkører (fylker/kommuner) gruppert etter navn med observasjonsantall.
     /// Hybrid tilnærming: uten filtre brukes pre-beregnet antall fra Area-tabellen,

--- a/Artskart3.Tests.Integration/Tests/SearchEndpointTests.cs
+++ b/Artskart3.Tests.Integration/Tests/SearchEndpointTests.cs
@@ -122,14 +122,15 @@ public class SearchEndpointTests : IAsyncLifetime
     // -----------------------------------------------------------------------
 
     [Fact]
-    public async Task GetObservationLocations_WithNoFilter_Returns200WithGeoJson()
+    public async Task GetObservationLocations_WithNoFilter_Returns200WithCompactJson()
     {
         var response = await _client.PostAsJsonAsync("/api/Search/Locations", new { });
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var json = await response.Content.ReadAsStringAsync();
         var doc = JsonDocument.Parse(json);
-        doc.RootElement.GetProperty("type").GetString().Should().Be("FeatureCollection");
+        doc.RootElement.GetProperty("epsg").GetInt32().Should().Be(25833);
+        doc.RootElement.GetProperty("locations").ValueKind.Should().Be(JsonValueKind.Array);
     }
 
     [Fact]
@@ -165,14 +166,14 @@ public class SearchEndpointTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task GetObservationLocations_WithMaxResults10_ReturnsAtMost10Features()
+    public async Task GetObservationLocations_WithMaxResults10_ReturnsAtMost10Locations()
     {
         var response = await _client.PostAsJsonAsync("/api/Search/Locations", new { maxResults = 10 });
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var json = await response.Content.ReadAsStringAsync();
         var doc = JsonDocument.Parse(json);
-        doc.RootElement.GetProperty("features").GetArrayLength()
+        doc.RootElement.GetProperty("locations").GetArrayLength()
             .Should().BeLessThanOrEqualTo(10);
     }
 

--- a/Artskart3.Tests.Integration/Tests/SearchRepositoryIntegrationTests.cs
+++ b/Artskart3.Tests.Integration/Tests/SearchRepositoryIntegrationTests.cs
@@ -72,10 +72,10 @@ public class SearchRepositoryIntegrationTests : IAsyncLifetime
     [Fact]
     public async Task GetLocationsAsync_GroupsObservationsByLocation()
     {
-        var result = await ToListAsync(_repository.GetLocationsAsync(new LocationSearchFilterDto
+        var result = await _repository.GetLocationsAsync(new LocationSearchFilterDto
         {
             TaxonGroupIds = new[] { TestObservationTaxonGroupOneId, TestObservationTaxonGroupTwoId }
-        }));
+        });
 
         result.Should().HaveCount(3);
         result.Should().Contain(model => model.Id == _locationOne.Id && model.ObservationCount == 3);
@@ -86,10 +86,10 @@ public class SearchRepositoryIntegrationTests : IAsyncLifetime
     [Fact]
     public async Task GetLocationsAsync_OrdersByObservationCountDescending()
     {
-        var result = await ToListAsync(_repository.GetLocationsAsync(new LocationSearchFilterDto
+        var result = await _repository.GetLocationsAsync(new LocationSearchFilterDto
         {
             TaxonGroupIds = new[] { TestObservationTaxonGroupOneId, TestObservationTaxonGroupTwoId }
-        }));
+        });
 
         result.Select(x => x.ObservationCount).Should().BeInDescendingOrder();
     }
@@ -97,10 +97,10 @@ public class SearchRepositoryIntegrationTests : IAsyncLifetime
     [Fact]
     public async Task GetLocationsAsync_FiltersByTaxonGroupId()
     {
-        var result = await ToListAsync(_repository.GetLocationsAsync(new LocationSearchFilterDto
+        var result = await _repository.GetLocationsAsync(new LocationSearchFilterDto
         {
             TaxonGroupIds = new[] { TestObservationTaxonGroupOneId }
-        }));
+        });
 
         // Should return only locations that have observations with TestObservationTaxonGroupOneId
         result.Should().NotBeEmpty();
@@ -114,10 +114,10 @@ public class SearchRepositoryIntegrationTests : IAsyncLifetime
     [Fact]
     public async Task GetLocationsAsync_FiltersByTaxonGroupIdOnly()
     {
-        var result = await ToListAsync(_repository.GetLocationsAsync(new LocationSearchFilterDto
+        var result = await _repository.GetLocationsAsync(new LocationSearchFilterDto
         {
             TaxonGroupIds = new[] { TestObservationTaxonGroupOneId }
-        }));
+        });
 
         result.Should().NotBeEmpty();
         result.Select(x => x.Id).Should().Contain(_locationOne.Id);
@@ -128,10 +128,10 @@ public class SearchRepositoryIntegrationTests : IAsyncLifetime
     [Fact]
     public async Task GetLocationsAsync_FiltersByCategory()
     {
-        var result = await ToListAsync(_repository.GetLocationsAsync(new LocationSearchFilterDto
+        var result = await _repository.GetLocationsAsync(new LocationSearchFilterDto
         {
             CategoryIds = new[] { TestCategoryOneId }
-        }));
+        });
 
         result.Should().ContainSingle();
         result[0].Id.Should().Be(_locationOne.Id);
@@ -140,10 +140,10 @@ public class SearchRepositoryIntegrationTests : IAsyncLifetime
     [Fact]
     public async Task GetLocationsAsync_FiltersByBasisOfRecord()
     {
-        var result = await ToListAsync(_repository.GetLocationsAsync(new LocationSearchFilterDto
+        var result = await _repository.GetLocationsAsync(new LocationSearchFilterDto
         {
             BasisOfRecordIds = new[] { TestBasisOfRecordOneId }
-        }));
+        });
 
         result.Select(location => location.Id).Should().BeEquivalentTo([_locationOne.Id, _locationThree.Id]);
     }
@@ -154,11 +154,11 @@ public class SearchRepositoryIntegrationTests : IAsyncLifetime
     [Fact]
     public async Task GetLocationsAsync_FiltersByCoordinatePrecisionFrom()
     {
-        var result = await ToListAsync(_repository.GetLocationsAsync(new LocationSearchFilterDto
+        var result = await _repository.GetLocationsAsync(new LocationSearchFilterDto
         {
             TaxonGroupIds = new[] { TestObservationTaxonGroupOneId, TestObservationTaxonGroupTwoId },
             CoordinatePrecision = new CoordinatePrecisionDto { From = 100 }
-        }));
+        });
 
         result.Select(location => location.Id).Should().BeEquivalentTo([_locationTwo.Id, _locationThree.Id]);
     }
@@ -166,11 +166,11 @@ public class SearchRepositoryIntegrationTests : IAsyncLifetime
     [Fact]
     public async Task GetLocationsAsync_FiltersByCoordinatePrecisionTo()
     {
-        var result = await ToListAsync(_repository.GetLocationsAsync(new LocationSearchFilterDto
+        var result = await _repository.GetLocationsAsync(new LocationSearchFilterDto
         {
             TaxonGroupIds = new[] { TestObservationTaxonGroupOneId, TestObservationTaxonGroupTwoId },
             CoordinatePrecision = new CoordinatePrecisionDto { To = 50 }
-        }));
+        });
 
         result.Should().ContainSingle();
         result[0].Id.Should().Be(_locationOne.Id);
@@ -179,11 +179,11 @@ public class SearchRepositoryIntegrationTests : IAsyncLifetime
     [Fact]
     public async Task GetLocationsAsync_LimitsToMaxResults()
     {
-        var result = await ToListAsync(_repository.GetLocationsAsync(new LocationSearchFilterDto
+        var result = await _repository.GetLocationsAsync(new LocationSearchFilterDto
         {
             TaxonGroupIds = new[] { TestObservationTaxonGroupOneId, TestObservationTaxonGroupTwoId },
             MaxResults = 2
-        }));
+        });
 
         result.Should().HaveCount(2);
         result.Select(location => location.Id).Should().ContainInOrder(_locationOne.Id, _locationTwo.Id);
@@ -409,14 +409,4 @@ public class SearchRepositoryIntegrationTests : IAsyncLifetime
             WktPolygon = null
         };
 
-    private static async Task<List<T>> ToListAsync<T>(IAsyncEnumerable<T> source)
-    {
-        var list = new List<T>();
-        await foreach (var item in source)
-        {
-            list.Add(item);
-        }
-
-        return list;
-    }
 }

--- a/Artskart3.Tests.Unit/LocationModelTests.cs
+++ b/Artskart3.Tests.Unit/LocationModelTests.cs
@@ -1,5 +1,4 @@
 using Artskart3.Core.Domain.BusinessModels;
-using Artskart3.Core.Domain.Enums;
 using FluentAssertions;
 
 namespace Artskart3.Tests.Unit;
@@ -7,7 +6,7 @@ namespace Artskart3.Tests.Unit;
 public class LocationModelTests
 {
     [Fact]
-    public void ObservationCount_ReturnsBackingField_WhenObservationsIsEmpty()
+    public void ObservationCount_CanBeSetAndRetrieved()
     {
         var sut = new LocationModel { ObservationCount = 7 };
 
@@ -15,79 +14,13 @@ public class LocationModelTests
     }
 
     [Fact]
-    public void ObservationCount_UsesObservationsCount_WhenObservationsArePopulated()
-    {
-        var sut = new LocationModel
-        {
-            ObservationCount = 1,
-            Observations =
-            {
-                new ObservationModel(),
-                new ObservationModel(),
-                new ObservationModel()
-            }
-        };
-
-        sut.ObservationCount.Should().Be(3);
-    }
-
-    [Fact]
-    public void ObservationCount_SetterWorksIndependently_WhenObservationsAreCleared()
-    {
-        var sut = new LocationModel
-        {
-            Observations =
-            {
-                new ObservationModel(),
-                new ObservationModel()
-            }
-        };
-
-        _ = sut.ObservationCount;
-        sut.Observations.Clear();
-        sut.ObservationCount = 9;
-
-        sut.ObservationCount.Should().Be(9);
-    }
-
-    [Fact]
-    public void MaxCategory_ReturnsUnknown_WhenObservationsIsEmpty()
+    public void DefaultValues_AreZero()
     {
         var sut = new LocationModel();
 
-        sut.MaxCategory.Should().Be(Category.Unknown);
-    }
-
-    [Fact]
-    public void MaxCategory_ReturnsHighestCategory_WhenObservationsContainObservationModels()
-    {
-        var sut = new LocationModel
-        {
-            Observations =
-            {
-                new ObservationModel { Category = Category.NT },
-                new ObservationWithLocationModel { Category = Category.CR }
-            }
-        };
-
-        sut.MaxCategory.Should().Be(Category.CR);
-    }
-
-    [Fact]
-    public void MaxCategory_ThrowsException_WhenObservationHasUnexpectedType()
-    {
-        var sut = new LocationModel
-        {
-            Observations = { new FakeObservation() }
-        };
-
-        var act = () => sut.MaxCategory;
-
-        act.Should().Throw<Exception>()
-            .WithMessage("Cast of observation in Location.MaxCategory failed");
-    }
-
-    private sealed class FakeObservation : ObservationBaseModel
-    {
+        sut.Id.Should().Be(0);
+        sut.Latitude.Should().Be(0);
+        sut.Longitude.Should().Be(0);
+        sut.ObservationCount.Should().Be(0);
     }
 }

--- a/Artskart3.Tests.Unit/SearchControllerAdditionalTests.cs
+++ b/Artskart3.Tests.Unit/SearchControllerAdditionalTests.cs
@@ -2,8 +2,11 @@ using Artskart3.Api.Controllers;
 using Artskart3.Core.Application.Configuration;
 using Artskart3.Core.Application.DTOs;
 using Artskart3.Core.Application.Services.Interfaces;
+using Artskart3.Core.Domain.BusinessModels;
 using FluentAssertions;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -61,16 +64,16 @@ public class SearchControllerAdditionalTests
     {
         var sut = CreateSut();
         _serviceMock
-            .Setup(s => s.GetLocationsAsync(It.IsAny<LocationSearchFilterDto>()))
-            .ReturnsAsync("{\"type\":\"FeatureCollection\",\"features\":[]}");
+            .Setup(s => s.GetLocationsAsync(It.IsAny<LocationSearchFilterDto>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<LocationModel>());
 
-        var result = await sut.GetObservationLocations(new LocationSearchFilterDto { CoordinatePrecision = new CoordinatePrecisionDto { From = 10 } });
+        await sut.GetObservationLocations(new LocationSearchFilterDto { CoordinatePrecision = new CoordinatePrecisionDto { From = 10 } });
 
-        result.Result.Should().BeOfType<ContentResult>();
+        sut.HttpContext.Response.ContentType.Should().Be("application/json");
         _serviceMock.Verify(s => s.GetLocationsAsync(It.Is<LocationSearchFilterDto>(f =>
             f.CoordinatePrecision != null &&
             f.CoordinatePrecision.From == 10 &&
-            f.CoordinatePrecision.To == null)), Times.Once);
+            f.CoordinatePrecision.To == null), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -78,17 +81,30 @@ public class SearchControllerAdditionalTests
     {
         var sut = CreateSut();
         _serviceMock
-            .Setup(s => s.GetLocationsAsync(It.IsAny<LocationSearchFilterDto>()))
-            .ReturnsAsync("{\"type\":\"FeatureCollection\",\"features\":[]}");
+            .Setup(s => s.GetLocationsAsync(It.IsAny<LocationSearchFilterDto>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<LocationModel>());
 
-        var result = await sut.GetObservationLocations(new LocationSearchFilterDto { CoordinatePrecision = new CoordinatePrecisionDto { To = 100 } });
+        await sut.GetObservationLocations(new LocationSearchFilterDto { CoordinatePrecision = new CoordinatePrecisionDto { To = 100 } });
 
-        result.Result.Should().BeOfType<ContentResult>();
+        sut.HttpContext.Response.ContentType.Should().Be("application/json");
         _serviceMock.Verify(s => s.GetLocationsAsync(It.Is<LocationSearchFilterDto>(f =>
             f.CoordinatePrecision != null &&
             f.CoordinatePrecision.From == null &&
-            f.CoordinatePrecision.To == 100)), Times.Once);
+            f.CoordinatePrecision.To == 100), It.IsAny<CancellationToken>()), Times.Once);
     }
 
-    private SearchController CreateSut() => new(_serviceMock.Object, _speciesServiceMock.Object, _loggerMock.Object, Options.Create(new PaginationOptions()));
+    private SearchController CreateSut()
+    {
+        var controller = new SearchController(_serviceMock.Object, _speciesServiceMock.Object, _loggerMock.Object, Options.Create(new PaginationOptions()));
+        var services = new ServiceCollection();
+        services.AddMvcCore();
+        services.AddLogging();
+        var httpContext = new DefaultHttpContext
+        {
+            RequestServices = services.BuildServiceProvider(),
+            Response = { Body = new MemoryStream() }
+        };
+        controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+        return controller;
+    }
 }

--- a/Artskart3.Tests.Unit/SearchControllerTests.cs
+++ b/Artskart3.Tests.Unit/SearchControllerTests.cs
@@ -2,8 +2,11 @@ using Artskart3.Api.Controllers;
 using Artskart3.Core.Application.Configuration;
 using Artskart3.Core.Application.DTOs;
 using Artskart3.Core.Application.Services.Interfaces;
+using Artskart3.Core.Domain.BusinessModels;
 using FluentAssertions;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -23,6 +26,16 @@ public class SearchControllerTests
         _speciesServiceMock = new Mock<ISpeciesService>();
         _loggerMock = new Mock<ILogger<SearchController>>();
         _sut = new SearchController(_serviceMock.Object, _speciesServiceMock.Object, _loggerMock.Object, Options.Create(new PaginationOptions()));
+
+        var services = new ServiceCollection();
+        services.AddMvcCore();
+        services.AddLogging();
+        var httpContext = new DefaultHttpContext
+        {
+            RequestServices = services.BuildServiceProvider(),
+            Response = { Body = new MemoryStream() }
+        };
+        _sut.ControllerContext = new ControllerContext { HttpContext = httpContext };
     }
 
     // -----------------------------------------------------------------------
@@ -100,60 +113,72 @@ public class SearchControllerTests
     [InlineData(0)]
     [InlineData(100001)]
     [InlineData(-1)]
-    public async Task GetObservationLocations_WithInvalidMaxResults_ReturnsBadRequest(int maxResults)
+    public async Task GetObservationLocations_WithInvalidMaxResults_Returns400(int maxResults)
     {
         var filter = new LocationSearchFilterDto { MaxResults = maxResults };
+        _sut.HttpContext.Response.Body = new MemoryStream();
 
-        var result = await _sut.GetObservationLocations(filter);
+        await _sut.GetObservationLocations(filter);
 
-        result.Result.Should().BeOfType<BadRequestObjectResult>();
+        _sut.HttpContext.Response.StatusCode.Should().Be(400);
     }
 
     [Fact]
-    public async Task GetObservationLocations_WhenPrecisionFromExceedsPrecisionTo_ReturnsBadRequest()
+    public async Task GetObservationLocations_WhenPrecisionFromExceedsPrecisionTo_Returns400()
     {
         var filter = new LocationSearchFilterDto
         {
             CoordinatePrecision = new CoordinatePrecisionDto { From = 500, To = 100 }
         };
+        _sut.HttpContext.Response.Body = new MemoryStream();
 
-        var result = await _sut.GetObservationLocations(filter);
+        await _sut.GetObservationLocations(filter);
 
-        result.Result.Should().BeOfType<BadRequestObjectResult>();
+        _sut.HttpContext.Response.StatusCode.Should().Be(400);
     }
 
     [Fact]
-    public async Task GetObservationLocations_WithValidFilter_ReturnsContentResult()
+    public async Task GetObservationLocations_WithValidFilter_WritesJsonToResponseBody()
     {
-        var geoJson = """{"type":"FeatureCollection","features":[]}""";
+        var locations = new List<LocationModel>
+        {
+            new() { Id = 1, Latitude = 59.9, Longitude = 10.7, ObservationCount = 3 }
+        };
         _serviceMock
-            .Setup(s => s.GetLocationsAsync(It.IsAny<LocationSearchFilterDto>()))
-            .ReturnsAsync(geoJson);
+            .Setup(s => s.GetLocationsAsync(It.IsAny<LocationSearchFilterDto>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(locations);
+        _sut.HttpContext.Response.Body = new MemoryStream();
 
-        var result = await _sut.GetObservationLocations(new LocationSearchFilterDto());
+        await _sut.GetObservationLocations(new LocationSearchFilterDto());
 
-        result.Result.Should().BeOfType<ContentResult>()
-            .Which.ContentType.Should().Be("application/json");
+        _sut.HttpContext.Response.ContentType.Should().Be("application/json");
+        _sut.HttpContext.Response.Body.Position = 0;
+        var body = await new StreamReader(_sut.HttpContext.Response.Body).ReadToEndAsync();
+        body.Should().Contain("\"locations\"");
+        body.Should().Contain("\"epsg\"");
     }
 
     [Fact]
     public async Task GetObservationLocations_WithNullFilter_UsesDefaultsAndSucceeds()
     {
         _serviceMock
-            .Setup(s => s.GetLocationsAsync(It.IsAny<LocationSearchFilterDto>()))
-            .ReturnsAsync("""{"type":"FeatureCollection","features":[]}""");
+            .Setup(s => s.GetLocationsAsync(It.IsAny<LocationSearchFilterDto>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<LocationModel>());
+        _sut.HttpContext.Response.Body = new MemoryStream();
 
-        var result = await _sut.GetObservationLocations(null);
+        await _sut.GetObservationLocations(null);
 
-        result.Result.Should().BeOfType<ContentResult>();
+        _sut.HttpContext.Response.ContentType.Should().Be("application/json");
+        _serviceMock.Verify(s => s.GetLocationsAsync(It.IsNotNull<LocationSearchFilterDto>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
     public async Task GetObservationLocations_WhenServiceThrowsApplicationException_Throws()
     {
         _serviceMock
-            .Setup(s => s.GetLocationsAsync(It.IsAny<LocationSearchFilterDto>()))
+            .Setup(s => s.GetLocationsAsync(It.IsAny<LocationSearchFilterDto>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new ApplicationException("DB error"));
+        _sut.HttpContext.Response.Body = new MemoryStream();
 
         var act = () => _sut.GetObservationLocations(new LocationSearchFilterDto());
 
@@ -164,8 +189,9 @@ public class SearchControllerTests
     public async Task GetObservationLocations_WhenServiceThrowsUnexpectedException_Throws()
     {
         _serviceMock
-            .Setup(s => s.GetLocationsAsync(It.IsAny<LocationSearchFilterDto>()))
+            .Setup(s => s.GetLocationsAsync(It.IsAny<LocationSearchFilterDto>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new Exception("Unexpected"));
+        _sut.HttpContext.Response.Body = new MemoryStream();
 
         var act = () => _sut.GetObservationLocations(new LocationSearchFilterDto());
 

--- a/Artskart3.Tests.Unit/SearchRepositoryTests.cs
+++ b/Artskart3.Tests.Unit/SearchRepositoryTests.cs
@@ -91,7 +91,7 @@ public class SearchRepositoryTests
 
         await context.SaveChangesAsync();
 
-        var result = await ToListAsync(sut.GetLocationsAsync(null));
+        var result = await sut.GetLocationsAsync(null);
 
         result.Should().HaveCount(2);
         result.Select(x => x.Id).Should().BeEquivalentTo([1, 2]);
@@ -113,7 +113,7 @@ public class SearchRepositoryTests
 
         await context.SaveChangesAsync();
 
-        var result = await ToListAsync(sut.GetLocationsAsync(new LocationSearchFilterDto { TaxonGroupIds = new[] { 1 } }));
+        var result = await sut.GetLocationsAsync(new LocationSearchFilterDto { TaxonGroupIds = new[] { 1 } });
 
         result.Should().ContainSingle();
         result[0].Id.Should().Be(1);
@@ -135,7 +135,7 @@ public class SearchRepositoryTests
 
         await context.SaveChangesAsync();
 
-        var result = await ToListAsync(sut.GetLocationsAsync(new LocationSearchFilterDto { CategoryIds = new[] { 10 } }));
+        var result = await sut.GetLocationsAsync(new LocationSearchFilterDto { CategoryIds = new[] { 10 } });
 
         result.Should().ContainSingle();
         result[0].Id.Should().Be(1);
@@ -157,7 +157,7 @@ public class SearchRepositoryTests
 
         await context.SaveChangesAsync();
 
-        var result = await ToListAsync(sut.GetLocationsAsync(new LocationSearchFilterDto { BasisOfRecordIds = new[] { 5 } }));
+        var result = await sut.GetLocationsAsync(new LocationSearchFilterDto { BasisOfRecordIds = new[] { 5 } });
 
         result.Should().ContainSingle();
         result[0].Id.Should().Be(1);
@@ -196,7 +196,7 @@ public class SearchRepositoryTests
 
         await context.SaveChangesAsync();
 
-        var result = await ToListAsync(sut.GetLocationsAsync(new LocationSearchFilterDto { RegistrationStatusId = 1 }));
+        var result = await sut.GetLocationsAsync(new LocationSearchFilterDto { RegistrationStatusId = 1 });
 
         result.Select(x => x.Id).Should().BeEquivalentTo([1, 4]);
     }
@@ -221,7 +221,7 @@ public class SearchRepositoryTests
         SeedObservations(context, absentObservation, foundObservation);
         await context.SaveChangesAsync();
 
-        var result = await ToListAsync(sut.GetLocationsAsync(new LocationSearchFilterDto { RegistrationStatusId = 2 }));
+        var result = await sut.GetLocationsAsync(new LocationSearchFilterDto { RegistrationStatusId = 2 });
 
         result.Should().ContainSingle();
         result[0].Id.Should().Be(1);
@@ -247,7 +247,7 @@ public class SearchRepositoryTests
         SeedObservations(context, notRecoveredObservation, foundObservation);
         await context.SaveChangesAsync();
 
-        var result = await ToListAsync(sut.GetLocationsAsync(new LocationSearchFilterDto { RegistrationStatusId = 3 }));
+        var result = await sut.GetLocationsAsync(new LocationSearchFilterDto { RegistrationStatusId = 3 });
 
         result.Should().ContainSingle();
         result[0].Id.Should().Be(1);
@@ -274,7 +274,7 @@ public class SearchRepositoryTests
 
         await context.SaveChangesAsync();
 
-        var result = await ToListAsync(sut.GetLocationsAsync(new LocationSearchFilterDto { CoordinatePrecision = new CoordinatePrecisionDto { From = 50 } }));
+        var result = await sut.GetLocationsAsync(new LocationSearchFilterDto { CoordinatePrecision = new CoordinatePrecisionDto { From = 50 } });
 
         result.Select(x => x.Id).Should().BeEquivalentTo([2, 3]);
     }
@@ -297,7 +297,7 @@ public class SearchRepositoryTests
 
         await context.SaveChangesAsync();
 
-        var result = await ToListAsync(sut.GetLocationsAsync(new LocationSearchFilterDto { CoordinatePrecision = new CoordinatePrecisionDto { To = 50 } }));
+        var result = await sut.GetLocationsAsync(new LocationSearchFilterDto { CoordinatePrecision = new CoordinatePrecisionDto { To = 50 } });
 
         result.Select(x => x.Id).Should().BeEquivalentTo([1, 2]);
     }
@@ -320,10 +320,10 @@ public class SearchRepositoryTests
 
         await context.SaveChangesAsync();
 
-        var result = await ToListAsync(sut.GetLocationsAsync(new LocationSearchFilterDto
+        var result = await sut.GetLocationsAsync(new LocationSearchFilterDto
         {
             CoordinatePrecision = new CoordinatePrecisionDto { From = 25, To = 75 }
-        }));
+        });
 
         result.Should().ContainSingle();
         result[0].Id.Should().Be(2);
@@ -350,7 +350,7 @@ public class SearchRepositoryTests
 
         await context.SaveChangesAsync();
 
-        var result = await ToListAsync(sut.GetLocationsAsync(new LocationSearchFilterDto { MaxResults = 2 }));
+        var result = await sut.GetLocationsAsync(new LocationSearchFilterDto { MaxResults = 2 });
 
         result.Should().HaveCount(2);
         result.Select(x => x.Id).Should().ContainInOrder(1, 2);
@@ -374,7 +374,7 @@ public class SearchRepositoryTests
 
         await context.SaveChangesAsync();
 
-        var result = await ToListAsync(sut.GetLocationsAsync(new LocationSearchFilterDto { MaxResults = 100001 }));
+        var result = await sut.GetLocationsAsync(new LocationSearchFilterDto { MaxResults = 100001 });
 
         result.Should().HaveCount(1000);
     }
@@ -390,7 +390,7 @@ public class SearchRepositoryTests
 
         await context.SaveChangesAsync();
 
-        var result = await ToListAsync(sut.GetLocationsAsync(new LocationSearchFilterDto { TaxonGroupIds = new[] { 99 } }));
+        var result = await sut.GetLocationsAsync(new LocationSearchFilterDto { TaxonGroupIds = new[] { 99 } });
 
         result.Should().BeEmpty();
     }
@@ -413,7 +413,7 @@ public class SearchRepositoryTests
 
         await context.SaveChangesAsync();
 
-        var result = await ToListAsync(sut.GetLocationsAsync(new LocationSearchFilterDto { TaxonGroupIds = new[] { 1, 2 } }));
+        var result = await sut.GetLocationsAsync(new LocationSearchFilterDto { TaxonGroupIds = new[] { 1, 2 } });
 
         result.Select(x => x.Id).Should().BeEquivalentTo([1, 2]);
     }
@@ -434,7 +434,7 @@ public class SearchRepositoryTests
 
         await context.SaveChangesAsync();
 
-        var result = await ToListAsync(sut.GetLocationsAsync(new LocationSearchFilterDto { TaxonGroupIds = null }));
+        var result = await sut.GetLocationsAsync(new LocationSearchFilterDto { TaxonGroupIds = null });
 
         result.Should().HaveCount(2);
     }
@@ -453,7 +453,7 @@ public class SearchRepositoryTests
 
         await context.SaveChangesAsync();
 
-        var result = await ToListAsync(sut.GetLocationsAsync(new LocationSearchFilterDto()));
+        var result = await sut.GetLocationsAsync(new LocationSearchFilterDto());
 
         result.Should().ContainSingle();
         result[0].ObservationCount.Should().Be(3);
@@ -474,7 +474,7 @@ public class SearchRepositoryTests
 
         await context.SaveChangesAsync();
 
-        var result = await ToListAsync(sut.GetLocationsAsync(new LocationSearchFilterDto()));
+        var result = await sut.GetLocationsAsync(new LocationSearchFilterDto());
 
         result.Should().ContainSingle();
         result[0].ObservationCount.Should().Be(4);
@@ -493,7 +493,7 @@ public class SearchRepositoryTests
 
         await context.SaveChangesAsync();
 
-        var result = await ToListAsync(sut.GetLocationsAsync(new LocationSearchFilterDto()));
+        var result = await sut.GetLocationsAsync(new LocationSearchFilterDto());
 
         result.Should().ContainSingle();
         result[0].Id.Should().Be(1);
@@ -593,14 +593,4 @@ public class SearchRepositoryTests
             Centroid = null
         };
 
-    private static async Task<List<T>> ToListAsync<T>(IAsyncEnumerable<T> source)
-    {
-        var list = new List<T>();
-        await foreach (var item in source)
-        {
-            list.Add(item);
-        }
-
-        return list;
-    }
 }

--- a/Artskart3.Tests.Unit/SearchServiceTests.cs
+++ b/Artskart3.Tests.Unit/SearchServiceTests.cs
@@ -72,11 +72,11 @@ public class SearchServiceTests
     public async Task GetLocationsAsync_ReturnsCompactJsonString()
     {
         _repositoryMock
-            .Setup(r => r.GetLocationsAsync(It.IsAny<LocationSearchFilterDto>()))
-            .Returns(AsyncEnumerable(new List<LocationModel>
+            .Setup(r => r.GetLocationsAsync(It.IsAny<LocationSearchFilterDto>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<LocationModel>
             {
-                new() { Id = 1, East = 262000, North = 6650000, Latitude = 59.9, Longitude = 10.7, ObservationCount = 3 }
-            }));
+                new() { Id = 1, Latitude = 59.9, Longitude = 10.7, ObservationCount = 3 }
+            });
 
         var result = await _sut.GetLocationsAsync(new LocationSearchFilterDto());
 
@@ -89,21 +89,21 @@ public class SearchServiceTests
     public async Task GetLocationsAsync_WithNullFilter_UsesDefaults()
     {
         _repositoryMock
-            .Setup(r => r.GetLocationsAsync(It.IsAny<LocationSearchFilterDto>()))
-            .Returns(AsyncEnumerable(new List<LocationModel>()));
+            .Setup(r => r.GetLocationsAsync(It.IsAny<LocationSearchFilterDto>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<LocationModel>());
 
         var result = await _sut.GetLocationsAsync(null);
 
         result.Should().NotBeNull();
-        _repositoryMock.Verify(r => r.GetLocationsAsync(It.IsNotNull<LocationSearchFilterDto>()), Times.Once);
+        _repositoryMock.Verify(r => r.GetLocationsAsync(It.IsNotNull<LocationSearchFilterDto>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
     public async Task GetLocationsAsync_WhenRepositoryThrows_WrapsInApplicationException()
     {
         _repositoryMock
-            .Setup(r => r.GetLocationsAsync(It.IsAny<LocationSearchFilterDto>()))
-            .Returns(ThrowingAsyncEnumerable<LocationModel>(new InvalidOperationException("DB down")));
+            .Setup(r => r.GetLocationsAsync(It.IsAny<LocationSearchFilterDto>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("DB down"));
 
         var act = () => _sut.GetLocationsAsync(new LocationSearchFilterDto());
 
@@ -113,13 +113,10 @@ public class SearchServiceTests
     [Fact]
     public async Task GetLocationsAsync_WithLargeDataSet_100000Items_ReturnsValidCompactJson()
     {
-        // Arrange: Create 100,000 location items
         var largeDataSet = Enumerable.Range(1, 100000)
             .Select(i => new LocationModel
             {
                 Id = i,
-                East = 262000 + i,
-                North = 6650000 + i,
                 Latitude = 59.9 + (i * 0.0001),
                 Longitude = 10.7 + (i * 0.0001),
                 ObservationCount = i % 10 + 1
@@ -127,38 +124,14 @@ public class SearchServiceTests
             .ToList();
 
         _repositoryMock
-            .Setup(r => r.GetLocationsAsync(It.IsAny<LocationSearchFilterDto>()))
-            .Returns(AsyncEnumerable(largeDataSet));
+            .Setup(r => r.GetLocationsAsync(It.IsAny<LocationSearchFilterDto>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(largeDataSet);
 
-        // Act
         var result = await _sut.GetLocationsAsync(new LocationSearchFilterDto());
 
-        // Assert
         result.Should().NotBeNullOrWhiteSpace();
         result.Should().Contain("\"locations\"");
         result.Should().Contain("\"epsg\"");
         result.Length.Should().BeGreaterThan(100000);
-    }
-
-    // -----------------------------------------------------------------------
-    // Hjelpemetoder
-    // -----------------------------------------------------------------------
-
-    private static async IAsyncEnumerable<T> AsyncEnumerable<T>(IEnumerable<T> items)
-    {
-        foreach (var item in items)
-        {
-            yield return item;
-            await Task.Yield();
-        }
-    }
-
-    private static async IAsyncEnumerable<T> ThrowingAsyncEnumerable<T>(Exception ex)
-    {
-        await Task.Yield();
-        throw ex;
-#pragma warning disable CS0162 // Unreachable code detected
-        yield break; // unreachable, but required by compiler
-#pragma warning restore CS0162 // Unreachable code detected
     }
 }

--- a/Artskart3.Tests.Unit/SearchServiceTests.cs
+++ b/Artskart3.Tests.Unit/SearchServiceTests.cs
@@ -69,20 +69,19 @@ public class SearchServiceTests
     // -----------------------------------------------------------------------
 
     [Fact]
-    public async Task GetLocationsAsync_ReturnsCompactJsonString()
+    public async Task GetLocationsAsync_ReturnsListFromRepository()
     {
+        var expected = new List<LocationModel>
+        {
+            new() { Id = 1, Latitude = 59.9, Longitude = 10.7, ObservationCount = 3 }
+        };
         _repositoryMock
             .Setup(r => r.GetLocationsAsync(It.IsAny<LocationSearchFilterDto>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<LocationModel>
-            {
-                new() { Id = 1, Latitude = 59.9, Longitude = 10.7, ObservationCount = 3 }
-            });
+            .ReturnsAsync(expected);
 
         var result = await _sut.GetLocationsAsync(new LocationSearchFilterDto());
 
-        result.Should().NotBeNullOrWhiteSpace();
-        result.Should().Contain("\"locations\"");
-        result.Should().Contain("\"epsg\"");
+        result.Should().BeEquivalentTo(expected);
     }
 
     [Fact]
@@ -94,12 +93,12 @@ public class SearchServiceTests
 
         var result = await _sut.GetLocationsAsync(null);
 
-        result.Should().NotBeNull();
+        result.Should().NotBeNull().And.BeEmpty();
         _repositoryMock.Verify(r => r.GetLocationsAsync(It.IsNotNull<LocationSearchFilterDto>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
-    public async Task GetLocationsAsync_WhenRepositoryThrows_WrapsInApplicationException()
+    public async Task GetLocationsAsync_WhenRepositoryThrows_PropagatesException()
     {
         _repositoryMock
             .Setup(r => r.GetLocationsAsync(It.IsAny<LocationSearchFilterDto>(), It.IsAny<CancellationToken>()))
@@ -107,11 +106,11 @@ public class SearchServiceTests
 
         var act = () => _sut.GetLocationsAsync(new LocationSearchFilterDto());
 
-        await act.Should().ThrowAsync<ApplicationException>();
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("DB down");
     }
 
     [Fact]
-    public async Task GetLocationsAsync_WithLargeDataSet_100000Items_ReturnsValidCompactJson()
+    public async Task GetLocationsAsync_WithLargeDataSet_100000Items_ReturnsAllItems()
     {
         var largeDataSet = Enumerable.Range(1, 100000)
             .Select(i => new LocationModel
@@ -129,9 +128,7 @@ public class SearchServiceTests
 
         var result = await _sut.GetLocationsAsync(new LocationSearchFilterDto());
 
-        result.Should().NotBeNullOrWhiteSpace();
-        result.Should().Contain("\"locations\"");
-        result.Should().Contain("\"epsg\"");
-        result.Length.Should().BeGreaterThan(100000);
+        result.Should().HaveCount(100000);
+        result.Should().BeEquivalentTo(largeDataSet);
     }
 }

--- a/Artskart3.Tests.Unit/SearchServiceTests.cs
+++ b/Artskart3.Tests.Unit/SearchServiceTests.cs
@@ -122,8 +122,7 @@ public class SearchServiceTests
                 North = 6650000 + i,
                 Latitude = 59.9 + (i * 0.0001),
                 Longitude = 10.7 + (i * 0.0001),
-                ObservationCount = i % 10 + 1,
-                Locality = $"Location-{i}"
+                ObservationCount = i % 10 + 1
             })
             .ToList();
 
@@ -138,7 +137,6 @@ public class SearchServiceTests
         result.Should().NotBeNullOrWhiteSpace();
         result.Should().Contain("\"locations\"");
         result.Should().Contain("\"epsg\"");
-        result.Should().Contain("Location-1");
         result.Length.Should().BeGreaterThan(100000);
     }
 

--- a/Artskart3.Tests.Unit/SearchServiceTests.cs
+++ b/Artskart3.Tests.Unit/SearchServiceTests.cs
@@ -69,7 +69,7 @@ public class SearchServiceTests
     // -----------------------------------------------------------------------
 
     [Fact]
-    public async Task GetLocationsAsync_ReturnsGeoJsonString()
+    public async Task GetLocationsAsync_ReturnsCompactJsonString()
     {
         _repositoryMock
             .Setup(r => r.GetLocationsAsync(It.IsAny<LocationSearchFilterDto>()))
@@ -81,7 +81,8 @@ public class SearchServiceTests
         var result = await _sut.GetLocationsAsync(new LocationSearchFilterDto());
 
         result.Should().NotBeNullOrWhiteSpace();
-        result.Should().Contain("FeatureCollection"); // GeoJSON root type
+        result.Should().Contain("\"locations\"");
+        result.Should().Contain("\"epsg\"");
     }
 
     [Fact]
@@ -110,7 +111,7 @@ public class SearchServiceTests
     }
 
     [Fact]
-    public async Task GetLocationsAsync_WithLargeDataSet_100000Items_ReturnsValidGeoJson()
+    public async Task GetLocationsAsync_WithLargeDataSet_100000Items_ReturnsValidCompactJson()
     {
         // Arrange: Create 100,000 location items
         var largeDataSet = Enumerable.Range(1, 100000)
@@ -135,9 +136,9 @@ public class SearchServiceTests
 
         // Assert
         result.Should().NotBeNullOrWhiteSpace();
-        result.Should().Contain("FeatureCollection");
-        result.Should().Contain("Feature");
-        result.Should().Contain("\"type\":\"Point\"");
+        result.Should().Contain("\"locations\"");
+        result.Should().Contain("\"epsg\"");
+        result.Should().Contain("Location-1");
         result.Length.Should().BeGreaterThan(100000);
     }
 

--- a/Artskart3.WebApp/src/app/core/services/areas/areas.service.ts
+++ b/Artskart3.WebApp/src/app/core/services/areas/areas.service.ts
@@ -330,8 +330,8 @@ export class AreasService {
   }
 
   /**
-   * Fetches locations as a serialized GeoJSON FeatureCollection string
-   * with per-feature `nbic:style` for direct use with `updateGeoJSONLayer`.
+   * Henter lokasjoner fra API (kompakt format) og returnerer GeoJSON FeatureCollection-streng
+   * med per-feature `nbic:style` for direkte bruk med `updateGeoJSONLayer`.
    * @param extent Kartutsnitt [minX, minY, maxX, maxY] i EPSG:25833
    * @param filter Valgfritt søkefilter for lokasjoner
    */
@@ -340,8 +340,8 @@ export class AreasService {
 
     return this.apiClientService.postJson<string>(this.locationsEndpoint, body, { responseType: 'text' }).pipe(
       map((responseText: string) => {
-        const parsed = this.apiClientService.parseJsonResponse<unknown>(responseText, AreasService.SERVICE_NAME);
-        const features = this.mapLocationsToGeoJson(parsed);
+        const parsed = this.apiClientService.parseJsonResponse<{ locations: unknown[] }>(responseText, AreasService.SERVICE_NAME);
+        const features = this.mapCompactLocationsToGeoJson(parsed);
         this.loggerService.info(`Retrieved ${features.length} location features`, AreasService.SERVICE_NAME);
         return JSON.stringify({ type: 'FeatureCollection', features });
       })
@@ -388,80 +388,34 @@ export class AreasService {
   }
 
   /**
-   * Maps API location response to GeoJSON features
+   * Mapper kompakt lokasjon-respons [id, lon, lat, count, locality] til GeoJSON-features.
    */
-  private mapLocationsToGeoJson(response: unknown): AreaMarkerFeature[] {
-    const locations = this.normalizeLocationResponse(response);
-    if (!Array.isArray(locations) || locations.length === 0) {
-      return [];
-    }
+  private mapCompactLocationsToGeoJson(response: unknown): AreaMarkerFeature[] {
+    if (typeof response !== 'object' || response === null) return [];
+    const locations = (response as { locations?: unknown[] }).locations;
+    if (!Array.isArray(locations)) return [];
 
-    return locations
-      .map(location => this.createLocationFeature(location))
-      .filter((f): f is AreaMarkerFeature => f !== null);
-  }
+    const features: AreaMarkerFeature[] = [];
+    for (const loc of locations) {
+      if (!Array.isArray(loc) || loc.length < 4) continue;
+      const [id, lon, lat, count, locality] = loc as [number, number, number, number, string?];
+      if (isNaN(lon) || isNaN(lat)) continue;
 
-  private normalizeLocationResponse(response: unknown): Record<string, unknown>[] {
-    if (Array.isArray(response)) {
-      return response as Record<string, unknown>[];
-    }
-
-    if (typeof response === 'object' && response !== null) {
-      const obj = response as Record<string, unknown>;
-      if (Array.isArray(obj['features'])) return obj['features'] as Record<string, unknown>[];
-      if (Array.isArray(obj['value'])) return obj['value'] as Record<string, unknown>[];
-      if (Array.isArray(obj['data'])) return obj['data'] as Record<string, unknown>[];
-    }
-
-    return [];
-  }
-
-  private createLocationFeature(location: Record<string, unknown>): AreaMarkerFeature | null {
-    try {
-      const [lon, lat] = this.extractCoordinates(location);
-      if (lon === null || lat === null) return null;
-
-      const props = (location['properties'] as Record<string, unknown>) || location;
-      const observationCount = (props['ObservationCount'] ?? props['observationCount'] ?? 0) as number;
-      const id = Number(location['id'] ?? props['TaxonId'] ?? props['taxonId']) || 0;
-      const name = (props['Locality'] ?? props['locality'] ?? props['name'] ?? `Location ${location['id']}`) as string;
-      const taxonId = (props['TaxonId'] ?? props['taxonId']) as number | undefined;
-
-      return {
+      features.push({
         type: 'Feature',
         id,
         geometry: { type: 'Point', coordinates: [lon, lat] },
         properties: {
           id,
-          name,
-          observationCount,
-          observationCountDisplay: observationCount ? AbbreviateNumberHelper.format(observationCount) : '',
+          name: locality ?? `Location ${id}`,
+          observationCount: count,
+          observationCountDisplay: count ? AbbreviateNumberHelper.format(count) : '',
           isPolygon: false,
-          ...(taxonId && { taxonId }),
           ...NBIC_LOCATION_STYLE
         }
-      };
-    } catch {
-      return null;
+      });
     }
-  }
-
-  private extractCoordinates(location: Record<string, unknown>): [number | null, number | null] {
-    const geometry = location['geometry'] as { type?: string; coordinates?: number[] } | undefined;
-    if (geometry?.type === 'Point' && geometry.coordinates?.length === 2) {
-      const [lon, lat] = geometry.coordinates;
-      if (!isNaN(lon) && !isNaN(lat)) {
-        return [lon, lat];
-      }
-    }
-
-    const lat = (location['latitude'] ?? location['lat']) as number | null;
-    const lon = (location['longitude'] ?? location['lon']) as number | null;
-    if (lat != null && lon != null && !isNaN(lat) && !isNaN(lon)) {
-      return [lon, lat];
-    }
-
-    return [null, null];
+    return features;
   }
 
   /**

--- a/Artskart3.WebApp/src/app/core/services/areas/areas.service.ts
+++ b/Artskart3.WebApp/src/app/core/services/areas/areas.service.ts
@@ -388,7 +388,7 @@ export class AreasService {
   }
 
   /**
-   * Mapper kompakt lokasjon-respons [id, lon, lat, count, locality] til GeoJSON-features.
+   * Mapper kompakt lokasjon-respons [id, lon, lat, count] til GeoJSON-features.
    */
   private mapCompactLocationsToGeoJson(response: unknown): AreaMarkerFeature[] {
     if (typeof response !== 'object' || response === null) return [];
@@ -398,7 +398,7 @@ export class AreasService {
     const features: AreaMarkerFeature[] = [];
     for (const loc of locations) {
       if (!Array.isArray(loc) || loc.length < 4) continue;
-      const [id, lon, lat, count, locality] = loc as [number, number, number, number, string?];
+      const [id, lon, lat, count] = loc as [number, number, number, number];
       if (isNaN(lon) || isNaN(lat)) continue;
 
       features.push({
@@ -407,7 +407,7 @@ export class AreasService {
         geometry: { type: 'Point', coordinates: [lon, lat] },
         properties: {
           id,
-          name: locality ?? `Location ${id}`,
+          name: `Location ${id}`,
           observationCount: count,
           observationCountDisplay: count ? AbbreviateNumberHelper.format(count) : '',
           isPolygon: false,

--- a/README.md
+++ b/README.md
@@ -157,3 +157,58 @@ Per juli 2026 er alle miljøene kun tilgjengelig dersom man er tilkoblet Artsdat
 * Opprett en PR som slår sammen staging-branchen inn i main-branchen
 * Når en reviewer har godkjent PR-en, velg merge. Main-branchen blir oppdatert og lukkes. 
 * Flytt issues fra "Accepted" til "Done" i projsktet-boardet. FERDIG.
+
+## Ytelsesoptimalisering
+
+### Database: Indekser
+
+| Dato | Beskrivelse |
+|------|-------------|
+| Apr 2026 | Lagt til komposittindekser på søkefilterkolonner i Observation-tabellen (`LocationId`, `TaxonGroupId`, `CategoryId`, `YearCollected`, `MonthCollected` m.m.) |
+| Jun 2026 | Lagt til dekkende indeks på `Area(AreaTypeId, Fid, IsCurrent)`, `LocationAreas(AreaId, LocationId)` og `OrganizationRelation(OrganizationId, ObservationId)` for raskere joins |
+| Jun 2026 | Erstattet to separate indekser på `ObservationEntityIndex` med en dekkende komposittindeks `(EntityTypeId, EntityId, ObservationId)`, pluss indeks på `Observation.DateTimeCollected` og `Area(ZoomLevel, IsCurrent)` |
+
+### Database: Denormalisering
+
+| Dato | Beskrivelse |
+|------|-------------|
+| Jun 2026 | Opprettet `ObservationEntityIndex`-tabell som flat projeksjon av observasjon-til-omrade-relasjoner — eliminerer dyre multi-tabell-joins for filtrering pa kommune, fylke, verneomrade, havomrade og institusjon |
+| Jun 2026 | Byttet fra `AreaFid` (string) til `EntityId` (int) i indekstabellen for raskere heltallssammenlikning |
+
+### Database: Sporringsoptimalisering
+
+| Dato | Beskrivelse |
+|------|-------------|
+| Mai 2026 | Erstattet Include-basert eager loading med `.Select()`-projeksjon slik at databasen kun returnerer kolonner som faktisk brukes i DTO-en |
+| Jun 2026 | Omskrev kommune-/fylkesfiltre fra korrelerte subsporreringer (`Location.Areas.Any()`) til to-stegs oppslag via `ObservationEntityIndex` |
+| Aug 2026 | Slo sammen to databasesporreringer til en for lokasjonsendepunktet — GROUP BY med JOIN i stedet for aggregering + separat koordinatoppslag |
+| Aug 2026 | Flyttet envelope-filter fra `Observation.East/North` (ingen indeks) til `Location.East/North` (bruker `IX_EastNorth`) |
+
+### API: Payload-reduksjon
+
+| Dato | Beskrivelse |
+|------|-------------|
+| Aug 2026 | Fjernet duplisert CRS per feature i GeoJSON (~5.5 MB spart ved 100k features) |
+| Aug 2026 | Erstattet GeoJSON med kompakt array-format `[id, lon, lat, count]` (~7x reduksjon) |
+| Aug 2026 | Fjernet `Locality` fra bulk-lokasjonsdata |
+| Aug 2026 | Forenklet `LocationModel` fra 15+ felt til 4, fjernet ubrukte felt fra DB-projeksjon |
+
+### API: Stromming og minnebruk
+
+| Dato | Beskrivelse |
+|------|-------------|
+| Aug 2026 | Strommer JSON direkte til `HttpResponse.Body` via `Utf8JsonWriter` i stedet for a mellomlagre som streng |
+| Aug 2026 | Fjernet unodvendig `IAsyncEnumerable`-wrapping rundt ferdig materialisert liste |
+
+### Frontend
+
+| Dato | Beskrivelse |
+|------|-------------|
+| Jun 2026 | Erstattet Angular pipe (`AreaNamePipe`) per rad i listevisning med forhandsberegnet `Map`-oppslag via computed signal — unngår lineart sok per rad per change detection |
+| Aug 2026 | Forenklet lokasjonsparsing fra fire metoder (regex-basert GeoJSON-parsing) til en enkel array-parser |
+
+### Infrastruktur
+
+| Dato | Beskrivelse |
+|------|-------------|
+| Jun 2026 | Lagt til `SlowQueryLog`-tabell og action filter som logger sporreringer over konfigurerbar terskel — muliggjor identifisering av trege endepunkter |


### PR DESCRIPTION
Gjort en del ytelsesforbedringer både med tanke på query, data som blir sendt fra api og minnebruk.

Her er hva som er gjort i grove trekk:
Nettverks-payload
  - Kompakt JSON-format — Erstattet GeoJSON FeatureCollection med et minimalt array-format { epsg, locations: [[id, lon, lat, count], ...] }. Fjerner all strukturell
   overhead per feature ("type":"Feature", "geometry", "properties" osv.). ~7x reduksjon i payloadstørrelse.
  - Fjernet duplisert CRS — CRS-objektet ("crs":{"properties":{"name":"EPSG:25833"},"type":"Name"}) ble skrevet per feature i tillegg til på FeatureCollection. ~55
  byte × 100k features = ~5.5 MB spart.
  - Fjernet Locality fra bulk-data — Lokalitetsnavn sendes ikke lenger i bulk-responsen. Kan eventuelt lazy-loades ved klikk.

  Database
  - Én spørring i stedet for to — Tidligere kjørte endepunktet først en aggregering (GROUP BY LocationId) på Observation-tabellen, og deretter en separat spørring
  for å hente koordinater fra Location-tabellen (med opptil 100k IDer i en IN-klausul). Nå gjøres alt i én spørring med JOIN.
  - Bruker IX_EastNorth-indeksen — Envelope-filteret (bounding box) filtrerte tidligere på Observation.East/North som ikke har indeks. Nå filtreres det via
  Location.East/North som har IX_EastNorth-indeksen.
  - Kun nødvendige kolonner fra databasen — Location-spørringen henter kun Id, Latitude og Longitude i stedet for alle kolonner (inkludert Geometry, LookupId,
  TimeStamp m.m.).

  Server (API)
  - Strømmer JSON direkte til HTTP-responsen — Skriver JSON direkte til Response.Body med Utf8JsonWriter i stedet for å serialisere til en mellomliggende streng.
  Unngår multi-MB strengallokering for store resultatsett.
  - Forenklet LocationModel — Redusert fra 15+ felt med kompleks logikk (Observations-collection, MaxCategory-beregning) til 4 enkle felt: Id, Latitude, Longitude,
  ObservationCount.
  - Fjernet unødvendig IAsyncEnumerable-wrapping — Repositoryet returnerte IAsyncEnumerable som bare wrappet en ferdig materialisert liste. Returnerer nå
  Task<List<LocationModel>> direkte.

  Frontend
  - Enklere parsing — Erstattet fire metoder for GeoJSON-parsing (inkludert regex-basert koordinatekstraksjon og fallback-logikk for ulike responsformater) med én
  enkel array-parser for det kompakte formatet.



For testing foreslår jeg at dere zoomer inn til lokasjoner hentes med develop branch (pan rundt for å trigge henting mange ganger) og holder et lite øye med datamengdene og querytimes. Så gjør det samme med denne branchen. Ikke noe vits å sammenlikne med test som er veldig mye tregere enn lokal maskin. Jeg så en reduksjon i datamengde med 3-4 ganger, og en querytid som ble 2-3 ganger kjappere.  