### PR TITLE
nye områdeinndeling og cache av data

### DIFF
--- a/Artskart3.Api/Controllers/SearchController.cs
+++ b/Artskart3.Api/Controllers/SearchController.cs
@@ -173,6 +173,49 @@ public class SearchController : ControllerBase
     }
 
     /// <summary>
+    /// Returns observation counts per area (FID) without geometry data.
+    /// Supports ETag-based caching — returns 304 Not Modified when counts haven't changed.
+    /// </summary>
+    [HttpPost("AreaCounts")]
+    [Produces("application/json")]
+    public async Task<IActionResult> GetAreaCounts(
+        [FromQuery] int zoomLevel = 1,
+        [FromBody] LocationSearchFilterDto? filter = null,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            if (zoomLevel < 1 || zoomLevel > 2)
+            {
+                return BadRequest(new { error = "zoomLevel must be 1 (counties) or 2 (municipalities)." });
+            }
+
+            if (filter != null && !ValidateLocationSearchFilter(filter, out var validationError))
+            {
+                return validationError!;
+            }
+
+            var result = await _searchService.GetAreaCountsAsync(zoomLevel, filter, cancellationToken);
+
+            var ifNoneMatch = Request.Headers.IfNoneMatch.ToString();
+            if (!string.IsNullOrEmpty(ifNoneMatch) && ifNoneMatch == result.Etag)
+            {
+                Response.Headers.ETag = result.Etag;
+                return StatusCode(304);
+            }
+
+            Response.Headers.ETag = result.Etag;
+            _logger.LogInformation("Retrieved {Count} area counts for zoom level {ZoomLevel}", result.Counts.Length, zoomLevel);
+            return Ok(result.Counts);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Feil ved henting av områdeantall");
+            throw;
+        }
+    }
+
+    /// <summary>
     /// Søker etter arter via NorTaxa-API.
     /// Hvis input er et heltall, slås det opp direkte på taxonId.
     /// Ellers utføres et navnesøk med maks 20 resultater.

--- a/Artskart3.Core/Application/DTOs/AreaCountDto.cs
+++ b/Artskart3.Core/Application/DTOs/AreaCountDto.cs
@@ -1,0 +1,9 @@
+namespace Artskart3.Core.Application.DTOs;
+
+public class AreaCountDto
+{
+    public string Fid { get; set; } = null!;
+    public int ObservationCount { get; set; }
+}
+
+public record AreaCountsResultDto(AreaCountDto[] Counts, string Etag);

--- a/Artskart3.Core/Application/DTOs/AreaResponseDto.cs
+++ b/Artskart3.Core/Application/DTOs/AreaResponseDto.cs
@@ -2,16 +2,10 @@ namespace Artskart3.Core.Application.DTOs;
 
 public class AreaResponseDto
 {
-    public CountyDto? Counties { get; set; }
+    public AreaTypeDto? Counties { get; set; }
     public AreaTypeDto? Municipalities { get; set; }
     public AreaTypeDto? RestrictedAreas { get; set; }
     public AreaTypeDto? OceanAreas { get; set; }
+    public AreaTypeDto? SvalbardBjørnøyaAndJanMayen { get; set; }
 
-}
-
-public class CountyDto
-{
-    public AreaDto[]? FastlandsNorge { get; set; }
-    public AreaDto? JanMayen { get; set; }
-    public AreaDto? Svalbard { get; set; }
 }

--- a/Artskart3.Core/Application/Services/Implementations/LookupService.cs
+++ b/Artskart3.Core/Application/Services/Implementations/LookupService.cs
@@ -23,22 +23,13 @@ public class LookupService : ILookupService
     {
         var areaTypes = await _lookupRepository.GetAreasAsync(cancellationToken);
 
-        // TODO HACK for å skille fastlandsnorge og svalbard, jan mayen, vi bør fikse dette ordentlig når vi setter opp ny import
-        // Fid "22" (Jan Mayen) og "21" (Svalbard) er fiktive fylkesnummer
-        // Svalbard har også et fiktivt fylkenummer 99 som ikke er med i denne omgang, har laget en egen task på dette for å undersøke hvordan det skal fungere
-        var countyAreaType = areaTypes.FirstOrDefault(at => at.Id == (int)AreaType.County);
-
         return new AreaResponseDto
         {
-            Counties = new CountyDto
-            {
-                FastlandsNorge = countyAreaType?.Areas.Where(a => a.Fid != "21" && a.Fid != "22").ToArray(),
-                JanMayen = countyAreaType?.Areas.FirstOrDefault(a => a.Fid == "22"),
-                Svalbard = countyAreaType?.Areas.FirstOrDefault(a => a.Fid == "21")
-            },
+            Counties = areaTypes.FirstOrDefault(at => at.Id == (int)AreaType.County),
             Municipalities = areaTypes.FirstOrDefault(at => at.Id == (int)AreaType.Municipality),
             RestrictedAreas = areaTypes.FirstOrDefault(at => at.Id == (int)AreaType.RestrictedArea),
             OceanAreas = areaTypes.FirstOrDefault(at => at.Id == (int)AreaType.OceanArea),
+            SvalbardBjørnøyaAndJanMayen = areaTypes.FirstOrDefault(at => at.Id == (int)AreaType.SvalbardBjørnøyaAndJanMayen)
         };
     }
 

--- a/Artskart3.Core/Application/Services/Implementations/SearchService.cs
+++ b/Artskart3.Core/Application/Services/Implementations/SearchService.cs
@@ -1,3 +1,6 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
 using Artskart3.Core.Application.DTOs;
 using Artskart3.Core.Application.Services.Interfaces;
 using Artskart3.Core.Domain.BusinessModels;
@@ -11,6 +14,7 @@ public class SearchService : ISearchService
     private readonly ISearchRepository _searchRepository;
     private readonly IMemoryCache _cache;
     private static readonly TimeSpan AreasCacheDuration = TimeSpan.FromHours(1);
+    private static readonly TimeSpan AreaCountsCacheDuration = TimeSpan.FromMinutes(5);
 
     public SearchService(ISearchRepository searchRepository, IMemoryCache cache)
     {
@@ -58,5 +62,44 @@ public class SearchService : ISearchService
     public async Task<IEnumerable<LocationPolygonDto>> GetLocationPolygonsAsync(LocationSearchFilterDto? filter = null, CancellationToken cancellationToken = default)
     {
         return await _searchRepository.GetLocationPolygonsAsync(filter, cancellationToken);
+    }
+
+    public async Task<AreaCountsResultDto> GetAreaCountsAsync(int zoomLevel, LocationSearchFilterDto? filter = null, CancellationToken cancellationToken = default)
+    {
+        // Bygg cache-nøkkel fra filter + zoomnivå
+        var filterJson = JsonSerializer.Serialize(filter ?? new LocationSearchFilterDto());
+        var keyHash = Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(filterJson)));
+        var cacheKey = $"area_counts_{zoomLevel}_{keyHash}";
+
+        if (_cache.TryGetValue(cacheKey, out AreaCountsResultDto? cached))
+        {
+            return cached!;
+        }
+
+        var hasFilters = filter?.HasActiveFilters == true;
+        AreaCountDto[] countsArray;
+
+        if (!hasFilters && zoomLevel is 1 or 2)
+        {
+            var markers = await GetAreaMarkersAsync(zoomLevel, null, cancellationToken);
+            countsArray = markers.Select(m => new AreaCountDto
+            {
+                Fid = m.Fid,
+                ObservationCount = m.ObservationCount ?? 0
+            }).ToArray();
+        }
+        else
+        {
+            countsArray = (await _searchRepository.GetAreaCountsAsync(zoomLevel, filter, cancellationToken)).ToArray();
+        }
+
+        var json = JsonSerializer.Serialize(countsArray);
+        var hash = MD5.HashData(Encoding.UTF8.GetBytes(json));
+        var etag = $"\"{Convert.ToHexStringLower(hash)}\"";
+
+        var result = new AreaCountsResultDto(countsArray, etag);
+        _cache.Set(cacheKey, result, AreaCountsCacheDuration);
+
+        return result;
     }
 }

--- a/Artskart3.Core/Application/Services/Interfaces/ISearchService.cs
+++ b/Artskart3.Core/Application/Services/Interfaces/ISearchService.cs
@@ -11,4 +11,5 @@ public interface ISearchService
 
     Task<IEnumerable<AreaMarkerDto>> GetAreaMarkersAsync(int zoomLevel, LocationSearchFilterDto? filter = null, CancellationToken cancellationToken = default);
     Task<IEnumerable<LocationPolygonDto>> GetLocationPolygonsAsync(LocationSearchFilterDto? filter = null, CancellationToken cancellationToken = default);
+    Task<AreaCountsResultDto> GetAreaCountsAsync(int zoomLevel, LocationSearchFilterDto? filter = null, CancellationToken cancellationToken = default);
 }

--- a/Artskart3.Core/Domain/Entities/ObservationAreaIndex.cs
+++ b/Artskart3.Core/Domain/Entities/ObservationAreaIndex.cs
@@ -10,4 +10,13 @@ public class ObservationEntityIndex
     public int ObservationId { get; set; }
     public int EntityTypeId { get; set; }
     public int EntityId { get; set; }
+
+    // Denormaliserte observasjonsattributter for rask filtrert telling
+    public int TaxonGroupId { get; set; }
+    public int? CategoryId { get; set; }
+    public int BasisOfRecordId { get; set; }
+    public int? CoordinatePrecisionInMeters { get; set; }
+    public DateTime? DateTimeCollected { get; set; }
+    public byte RegistrationStatusId { get; set; }
+    public bool HasMediaFiles { get; set; }
 }

--- a/Artskart3.Core/Domain/Enums/AreaType.cs
+++ b/Artskart3.Core/Domain/Enums/AreaType.cs
@@ -6,5 +6,7 @@ public enum AreaType
     Municipality = 1,
     County = 2,
     RestrictedArea = 3,
-    OceanArea = 4
+    OceanArea = 4,
+    NorwaysMarineAreas = 5, // Reservert for fremtidig bruk
+    SvalbardBjørnøyaAndJanMayen = 6,
 }

--- a/Artskart3.Core/Domain/Enums/ObservationIndexEntityType.cs
+++ b/Artskart3.Core/Domain/Enums/ObservationIndexEntityType.cs
@@ -13,6 +13,7 @@ public enum ObservationIndexEntityType
     County = 2,
     RestrictedArea = 3,
     OceanArea = 4,
+    SvalbardBjørnøyaAndJanMayen = 6,
 
     // Organisasjonstyper (100 + OrganizationType-verdi)
     Institution = 101

--- a/Artskart3.Core/Domain/RepositoryInterfaces/ISearchRepository.cs
+++ b/Artskart3.Core/Domain/RepositoryInterfaces/ISearchRepository.cs
@@ -10,4 +10,5 @@ public interface ISearchRepository
     Task<List<ObservationDto>> GetObservationsAsync(ObservationSearchFilterDto filter, CancellationToken cancellationToken = default);
     Task<IEnumerable<AreaMarkerDto>> GetAreaMarkersAsync(int zoomLevel, LocationSearchFilterDto? filter = null, CancellationToken cancellationToken = default);
     Task<IEnumerable<LocationPolygonDto>> GetLocationPolygonsAsync(LocationSearchFilterDto? filter = null, CancellationToken cancellationToken = default);
+    Task<IEnumerable<AreaCountDto>> GetAreaCountsAsync(int zoomLevel, LocationSearchFilterDto? filter = null, CancellationToken cancellationToken = default);
 }

--- a/Artskart3.Infrastructure/Data/DbContext/ArtskartDbContext.cs
+++ b/Artskart3.Infrastructure/Data/DbContext/ArtskartDbContext.cs
@@ -1029,7 +1029,9 @@ public partial class ArtskartDbContext : DbContext, IArtsKartDbContext
             entity.HasKey(e => new { e.ObservationId, e.EntityTypeId, e.EntityId });
             entity.ToTable("ObservationEntityIndex");
 
-            entity.HasIndex(e => new { e.EntityTypeId, e.EntityId, e.ObservationId }).HasDatabaseName("IX_ObservationEntityIndex_EntityType_EntityId_ObsId");
+            // Indeks for filtrert telling: dekker (EntityTypeId, EntityId) pluss vanlige filterkolonner
+            entity.HasIndex(e => new { e.EntityTypeId, e.EntityId, e.TaxonGroupId, e.CategoryId })
+                .HasDatabaseName("IX_ObservationEntityIndex_EntityLookup");
         });
 
         OnModelCreatingPartial(modelBuilder);

--- a/Artskart3.Infrastructure/Migrations/20260814125543_AddFilterColumnsToObservationEntityIndex.Designer.cs
+++ b/Artskart3.Infrastructure/Migrations/20260814125543_AddFilterColumnsToObservationEntityIndex.Designer.cs
@@ -4,6 +4,7 @@ using Artskart3.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 
@@ -12,9 +13,11 @@ using NetTopologySuite.Geometries;
 namespace Artskart3.Infrastructure.Migrations
 {
     [DbContext(typeof(ArtskartDbContext))]
-    partial class ArtskartDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260814125543_AddFilterColumnsToObservationEntityIndex")]
+    partial class AddFilterColumnsToObservationEntityIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Artskart3.Infrastructure/Migrations/20260814125543_AddFilterColumnsToObservationEntityIndex.cs
+++ b/Artskart3.Infrastructure/Migrations/20260814125543_AddFilterColumnsToObservationEntityIndex.cs
@@ -1,0 +1,93 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Artskart3.Infrastructure.Migrations;
+
+/// <inheritdoc />
+public partial class AddFilterColumnsToObservationEntityIndex : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        // Fjern gammel indeks først — unngår indeksvedlikehold under kolonne-tillegg med defaultverdier
+        migrationBuilder.DropIndex(
+            name: "IX_ObservationEntityIndex_EntityType_EntityId_ObsId",
+            table: "ObservationEntityIndex");
+
+        migrationBuilder.AddColumn<int>(
+            name: "BasisOfRecordId",
+            table: "ObservationEntityIndex",
+            type: "int",
+            nullable: false,
+            defaultValue: 0);
+
+        migrationBuilder.AddColumn<int>(
+            name: "CategoryId",
+            table: "ObservationEntityIndex",
+            type: "int",
+            nullable: true);
+
+        migrationBuilder.AddColumn<int>(
+            name: "CoordinatePrecisionInMeters",
+            table: "ObservationEntityIndex",
+            type: "int",
+            nullable: true);
+
+        migrationBuilder.AddColumn<DateTime>(
+            name: "DateTimeCollected",
+            table: "ObservationEntityIndex",
+            type: "datetime2",
+            nullable: true);
+
+        migrationBuilder.AddColumn<bool>(
+            name: "HasMediaFiles",
+            table: "ObservationEntityIndex",
+            type: "bit",
+            nullable: false,
+            defaultValue: false);
+
+        migrationBuilder.AddColumn<byte>(
+            name: "RegistrationStatusId",
+            table: "ObservationEntityIndex",
+            type: "tinyint",
+            nullable: false,
+            defaultValue: (byte)0);
+
+        migrationBuilder.AddColumn<int>(
+            name: "TaxonGroupId",
+            table: "ObservationEntityIndex",
+            type: "int",
+            nullable: false,
+            defaultValue: 0);
+
+        // MERK: Backfill kjøres manuelt via SQL-skript
+        // på grunn av lang kjøretid (300M+ rader). Se BackfillObservationEntityIndex.sql.
+        migrationBuilder.CreateIndex(
+            name: "IX_ObservationEntityIndex_EntityLookup",
+            table: "ObservationEntityIndex",
+            columns: new[] { "EntityTypeId", "EntityId", "TaxonGroupId", "CategoryId" });
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropIndex(
+            name: "IX_ObservationEntityIndex_EntityLookup",
+            table: "ObservationEntityIndex");
+
+        migrationBuilder.DropColumn(name: "BasisOfRecordId", table: "ObservationEntityIndex");
+        migrationBuilder.DropColumn(name: "CategoryId", table: "ObservationEntityIndex");
+        migrationBuilder.DropColumn(name: "CoordinatePrecisionInMeters", table: "ObservationEntityIndex");
+        migrationBuilder.DropColumn(name: "DateTimeCollected", table: "ObservationEntityIndex");
+        migrationBuilder.DropColumn(name: "HasMediaFiles", table: "ObservationEntityIndex");
+        migrationBuilder.DropColumn(name: "RegistrationStatusId", table: "ObservationEntityIndex");
+        migrationBuilder.DropColumn(name: "TaxonGroupId", table: "ObservationEntityIndex");
+
+        // Gjenopprett gammel indeks
+        migrationBuilder.CreateIndex(
+            name: "IX_ObservationEntityIndex_EntityType_EntityId_ObsId",
+            table: "ObservationEntityIndex",
+            columns: new[] { "EntityTypeId", "EntityId", "ObservationId" });
+    }
+}

--- a/Artskart3.Infrastructure/Persistence/Repositories/SearchRepository.cs
+++ b/Artskart3.Infrastructure/Persistence/Repositories/SearchRepository.cs
@@ -637,12 +637,13 @@ public class SearchRepository : ISearchRepository
 
     /// <summary>
     /// Beregner filtrerte observasjonsantall per område via ObservationEntityIndex.
+    /// Bruker denormaliserte kolonner (TaxonGroupId, CategoryId, etc.) direkte på indekstabellen
+    /// for å unngå tung subquery mot Observation-tabellen.
+    /// Faller tilbake til subquery for filtre som ikke er denormalisert (atferd, prosjekt, etc.).
     /// </summary>
     private async Task<Dictionary<(int entityTypeId, int entityId), int>> ComputeFilteredAreaCounts(
         List<Area> areas, LocationSearchFilterDto filter, CancellationToken cancellationToken)
     {
-        var filteredQuery = ApplyCommonFilters(_context.Set<Observation>().AsNoTracking(), filter);
-
         var entityTypeIds = areas.Select(a => a.AreaTypeId).Distinct().ToArray();
         var entityIds = areas
             .Select(a => _areaHierarchy.FidToEntityId(a.Fid))
@@ -651,9 +652,104 @@ public class SearchRepository : ISearchRepository
             .Distinct()
             .ToArray();
 
-        var counts = await _context.Set<ObservationEntityIndex>()
-            .Where(idx => entityTypeIds.Contains(idx.EntityTypeId) && entityIds.Contains(idx.EntityId))
-            .Where(idx => filteredQuery.Select(o => o.Id).Contains(idx.ObservationId))
+        var query = _context.Set<ObservationEntityIndex>()
+            .Where(idx => entityTypeIds.Contains(idx.EntityTypeId) && entityIds.Contains(idx.EntityId));
+
+        // Denormaliserte filtre — anvendes direkte på indekstabellen
+        if (filter.TaxonGroupIds?.Any() == true)
+        {
+            var ids = filter.TaxonGroupIds.ToList();
+            query = query.Where(idx => ids.Contains(idx.TaxonGroupId));
+        }
+
+        if (filter.CategoryIds?.Any() == true)
+        {
+            var ids = filter.CategoryIds.ToList();
+            query = query.Where(idx => idx.CategoryId.HasValue && ids.Contains(idx.CategoryId.Value));
+        }
+
+        if (filter.BasisOfRecordIds?.Any() == true)
+        {
+            var ids = filter.BasisOfRecordIds.ToList();
+            query = query.Where(idx => ids.Contains(idx.BasisOfRecordId));
+        }
+
+        if (filter.CoordinatePrecision?.From.HasValue == true)
+            query = query.Where(idx => idx.CoordinatePrecisionInMeters >= filter.CoordinatePrecision.From.Value);
+
+        if (filter.CoordinatePrecision?.To.HasValue == true)
+            query = query.Where(idx => idx.CoordinatePrecisionInMeters <= filter.CoordinatePrecision.To.Value);
+
+        if (filter.Period?.From.HasValue == true)
+        {
+            var fromDate = new DateTime(filter.Period.From.Value, 1, 1);
+            query = query.Where(idx => idx.DateTimeCollected >= fromDate);
+        }
+
+        if (filter.Period?.To.HasValue == true)
+        {
+            var toDate = new DateTime(filter.Period.To.Value, 12, 31, 23, 59, 59);
+            query = query.Where(idx => idx.DateTimeCollected <= toDate);
+        }
+
+        if (filter.Period?.Months?.Any() == true)
+        {
+            var months = filter.Period.Months;
+            query = query.Where(idx => idx.DateTimeCollected.HasValue && months.Contains(idx.DateTimeCollected.Value.Month));
+        }
+
+        if (filter.RegistrationStatusId.HasValue)
+        {
+            var statusId = (byte)filter.RegistrationStatusId.Value;
+            query = query.Where(idx => idx.RegistrationStatusId == statusId);
+        }
+
+        if (filter.WithImages.HasValue)
+        {
+            query = filter.WithImages.Value
+                ? query.Where(idx => idx.HasMediaFiles)
+                : query.Where(idx => !idx.HasMediaFiles);
+        }
+
+        // Filtre som ikke er denormalisert — krever subquery mot Observation-tabellen
+        var needsObservationSubquery =
+            filter.OrganizationIds?.Any() == true ||
+            filter.BehaviorIds?.Any() == true ||
+            !string.IsNullOrWhiteSpace(filter.ProjectName) ||
+            filter.ProjectOrganizationId.HasValue ||
+            !string.IsNullOrWhiteSpace(filter.CollectionCode) ||
+            !string.IsNullOrWhiteSpace(filter.CatalogNumber);
+
+        if (needsObservationSubquery)
+        {
+            var filteredObservations = ApplyCommonFilters(_context.Set<Observation>().AsNoTracking(), filter);
+            query = query.Where(idx => filteredObservations.Select(o => o.Id).Contains(idx.ObservationId));
+        }
+
+        // Geografiske filtre via ObservationEntityIndex (OR — observasjon i minst ett av områdene)
+        var hasMunicipality = filter.MunicipalityIds?.Any() == true;
+        var hasCounty = filter.CountyIds?.Any() == true;
+        var hasRestricted = filter.RestrictedAreaIds?.Any() == true;
+        var hasOcean = filter.OceanAreaIds?.Any() == true;
+
+        if (hasMunicipality || hasCounty || hasRestricted || hasOcean)
+        {
+            var municipalityIds = _areaHierarchy.FidsToEntityIds(filter.MunicipalityIds);
+            var countyIds = _areaHierarchy.FidsToEntityIds(filter.CountyIds);
+            var restrictedIds = _areaHierarchy.RestrictedAreaFidsToEntityIds(filter.RestrictedAreaIds);
+            var oceanIds = _areaHierarchy.FidsToEntityIds(filter.OceanAreaIds);
+
+            query = query.Where(idx => _context.Set<ObservationEntityIndex>().Any(geo =>
+                geo.ObservationId == idx.ObservationId && (
+                    (geo.EntityTypeId == (int)ObservationIndexEntityType.Municipality && municipalityIds.Contains(geo.EntityId)) ||
+                    (geo.EntityTypeId == (int)ObservationIndexEntityType.County && countyIds.Contains(geo.EntityId)) ||
+                    (geo.EntityTypeId == (int)ObservationIndexEntityType.SvalbardBjørnøyaAndJanMayen && countyIds.Contains(geo.EntityId)) ||
+                    (geo.EntityTypeId == (int)ObservationIndexEntityType.RestrictedArea && restrictedIds.Contains(geo.EntityId)) ||
+                    (geo.EntityTypeId == (int)ObservationIndexEntityType.OceanArea && oceanIds.Contains(geo.EntityId))
+                )));
+        }
+
+        var counts = await query
             .GroupBy(idx => new { idx.EntityTypeId, idx.EntityId })
             .Select(g => new { g.Key.EntityTypeId, g.Key.EntityId, Count = g.Count() })
             .ToListAsync(cancellationToken);

--- a/Artskart3.Infrastructure/Persistence/Repositories/SearchRepository.cs
+++ b/Artskart3.Infrastructure/Persistence/Repositories/SearchRepository.cs
@@ -316,6 +316,7 @@ public class SearchRepository : ISearchRepository
                 idx.ObservationId == o.Id && (
                     (idx.EntityTypeId == (int)ObservationIndexEntityType.Municipality && municipalityIds.Contains(idx.EntityId)) ||
                     (idx.EntityTypeId == (int)ObservationIndexEntityType.County && countyIds.Contains(idx.EntityId)) ||
+                    (idx.EntityTypeId == (int)ObservationIndexEntityType.SvalbardBjørnøyaAndJanMayen && countyIds.Contains(idx.EntityId)) ||
                     (idx.EntityTypeId == (int)ObservationIndexEntityType.RestrictedArea && restrictedIds.Contains(idx.EntityId)) ||
                     (idx.EntityTypeId == (int)ObservationIndexEntityType.OceanArea && oceanIds.Contains(idx.EntityId))
                 )));

--- a/Artskart3.Infrastructure/Persistence/Repositories/SearchRepository.cs
+++ b/Artskart3.Infrastructure/Persistence/Repositories/SearchRepository.cs
@@ -423,96 +423,133 @@ public class SearchRepository : ISearchRepository
     /// Hybrid tilnærming: uten filtre brukes pre-beregnet antall fra Area-tabellen,
     /// med filtre beregnes antall dynamisk via ObservationEntityIndex.
     /// </summary>
+    /// <summary>
+    /// Laster områder for et gitt zoomnivå, inkludert havområder og Svalbard/Bjørnøya/Jan Mayen
+    /// når de er i filteret eller vi laster zoomnivå 1 uten filtre (for prefetch av geometrier).
+    /// </summary>
+    private async Task<List<Area>> LoadAreasForZoomLevel(int zoomLevel, LocationSearchFilterDto? filter, CancellationToken cancellationToken)
+    {
+        var hasFilters = filter?.HasActiveFilters == true;
+
+        // For ufiltrert zoomnivå 1: last også havområder og Svalbard/Bjørnøya/Jan Mayen
+        // slik at frontend kan prefetche alle geometrier i én forespørsel
+        if (!hasFilters && zoomLevel == 1)
+        {
+            return await _context.Set<Area>()
+                .Where(a => a.IsCurrent == true && (
+                    a.ZoomLevel == zoomLevel ||
+                    a.AreaTypeId == (int)Artskart3.Core.Domain.Enums.AreaType.OceanArea ||
+                    a.AreaTypeId == (int)Artskart3.Core.Domain.Enums.AreaType.SvalbardBjørnøyaAndJanMayen
+                ))
+                .ToListAsync(cancellationToken);
+        }
+
+        var areas = await _context.Set<Area>()
+            .Where(a => a.ZoomLevel == zoomLevel && a.IsCurrent == true)
+            .ToListAsync(cancellationToken);
+
+        // Havområder kan ha et annet zoomnivå — last inn separat når de er i filteret
+        if (filter?.OceanAreaIds?.Any() == true)
+        {
+            var loadedFids = areas.Select(a => a.Fid).ToHashSet();
+            var missingOceanFids = filter.OceanAreaIds.Where(fid => !loadedFids.Contains(fid)).ToArray();
+            if (missingOceanFids.Length > 0)
+            {
+                var oceanAreas = await _context.Set<Area>()
+                    .Where(a => a.IsCurrent && missingOceanFids.Contains(a.Fid))
+                    .ToListAsync(cancellationToken);
+                areas.AddRange(oceanAreas);
+            }
+        }
+
+        return areas;
+    }
+
+    /// <summary>
+    /// Filtrerer områder og beregner observasjonsantall basert på aktive filtre.
+    /// Returnerer den filtrerte områdelisten og en funksjon for å slå opp antall per Fid.
+    /// </summary>
+    private async Task<(List<Area> areas, Func<IGrouping<string, Area>, int> countResolver)> FilterAndComputeCounts(
+        List<Area> areas, LocationSearchFilterDto? filter, CancellationToken cancellationToken)
+    {
+        var hasFilters = filter?.HasActiveFilters == true;
+        var needsDynamicCounts = hasFilters && filter!.HasObservationAttributeFilters;
+        Dictionary<(int entityTypeId, int entityId), int>? dynamicCounts = null;
+        Dictionary<string, int>? municipalityCountsByCounty = null;
+
+        // Steg 1: Filtrer hvilke områder som vises
+        var hasAreaSelection = hasFilters && (
+            filter!.CountyIds?.Length > 0 ||
+            filter.MunicipalityIds?.Length > 0 ||
+            filter.OceanAreaIds?.Length > 0);
+
+        if (hasAreaSelection)
+        {
+            var filtered = FilterAreasBySelection(areas, filter!);
+            if (filtered.Count > 0)
+            {
+                areas = filtered;
+            }
+            else if (!needsDynamicCounts)
+            {
+                areas = filtered;
+            }
+        }
+
+        // Steg 2: Bestem tellemåte
+        if (needsDynamicCounts)
+        {
+            dynamicCounts = await ComputeFilteredAreaCounts(areas, filter!, cancellationToken);
+        }
+        else if (hasAreaSelection)
+        {
+            var hasMunicipalityFilter = filter!.MunicipalityIds?.Length > 0;
+            var areasAreCounties = areas.Count > 0 && !areas.Any(a => filter.MunicipalityIds?.Contains(a.Fid) == true);
+
+            if (hasMunicipalityFilter && areasAreCounties)
+            {
+                municipalityCountsByCounty = await AggregateMunicipalityCountsByCounty(
+                    filter.MunicipalityIds!, cancellationToken);
+            }
+        }
+
+        int CountResolver(IGrouping<string, Area> g)
+        {
+            if (needsDynamicCounts)
+            {
+                return g.Sum(a =>
+                {
+                    var entityId = _areaHierarchy.FidToEntityId(a.Fid);
+                    return entityId.HasValue
+                        ? dynamicCounts!.GetValueOrDefault((a.AreaTypeId, entityId.Value), 0)
+                        : 0;
+                });
+            }
+
+            if (municipalityCountsByCounty != null)
+            {
+                return g.Sum(a => municipalityCountsByCounty.GetValueOrDefault(a.Fid, 0));
+            }
+
+            return g.Sum(a => a.ObservationCount ?? 0);
+        }
+
+        return (areas, CountResolver);
+    }
+
     public async Task<IEnumerable<AreaMarkerDto>> GetAreaMarkersAsync(int zoomLevel, LocationSearchFilterDto? filter = null, CancellationToken cancellationToken = default)
     {
         try
         {
-            var areas = await _context.Set<Area>()
-                    .Where(a => a.ZoomLevel == zoomLevel && a.IsCurrent == true)
-                    .ToListAsync(cancellationToken);
+            var areas = await LoadAreasForZoomLevel(zoomLevel, filter, cancellationToken);
+            var (filteredAreas, countResolver) = await FilterAndComputeCounts(areas, filter, cancellationToken);
 
-            // Havområder kan ha et annet zoomnivå — last inn separat når de er i filteret
-            if (filter?.OceanAreaIds?.Any() == true)
-            {
-                var loadedFids = areas.Select(a => a.Fid).ToHashSet();
-                var missingOceanFids = filter.OceanAreaIds.Where(fid => !loadedFids.Contains(fid)).ToArray();
-                if (missingOceanFids.Length > 0)
-                {
-                    var oceanAreas = await _context.Set<Area>()
-                        .Where(a => a.IsCurrent && missingOceanFids.Contains(a.Fid))
-                        .ToListAsync(cancellationToken);
-                    areas.AddRange(oceanAreas);
-                }
-            }
-
-            var hasFilters = filter?.HasActiveFilters == true;
-            var needsDynamicCounts = hasFilters && filter!.HasObservationAttributeFilters;
-            Dictionary<(int entityTypeId, int entityId), int>? dynamicCounts = null;
-            Dictionary<string, int>? municipalityCountsByCounty = null;
-
-            // Steg 1: Filtrer hvilke områder som vises (uavhengig av tellemåte)
-            var hasAreaSelection = hasFilters && (
-                filter!.CountyIds?.Length > 0 ||
-                filter.MunicipalityIds?.Length > 0 ||
-                filter.OceanAreaIds?.Length > 0);
-
-            if (hasAreaSelection)
-            {
-                var filtered = FilterAreasBySelection(areas, filter!);
-                if (filtered.Count > 0)
-                {
-                    areas = filtered;
-                }
-                else if (!needsDynamicCounts)
-                {
-                    // Ingen områder matcher og ingen observasjonsfiltre — ingen markører å vise
-                    areas = filtered;
-                }
-            }
-
-            // Steg 2: Bestem tellemåte
-            if (needsDynamicCounts)
-            {
-                dynamicCounts = await ComputeFilteredAreaCounts(areas, filter!, cancellationToken);
-            }
-            else if (hasAreaSelection)
-            {
-                // Sjekk om kommune-filter på fylkesnivå krever aggregering
-                var hasMunicipalityFilter = filter!.MunicipalityIds?.Length > 0;
-                var areasAreCounties = areas.Count > 0 && !areas.Any(a => filter.MunicipalityIds?.Contains(a.Fid) == true);
-
-                if (hasMunicipalityFilter && areasAreCounties)
-                {
-                    municipalityCountsByCounty = await AggregateMunicipalityCountsByCounty(
-                        filter.MunicipalityIds!, cancellationToken);
-                }
-            }
-
-            return areas
+            return filteredAreas
                 .GroupBy(a => a.Name)
                 .Select(g =>
                 {
                     var firstArea = g.FirstOrDefault(a => a.WktPolygon != null) ?? g.First();
-
-                    int count;
-                    if (needsDynamicCounts)
-                    {
-                        count = g.Sum(a =>
-                        {
-                            var entityId = _areaHierarchy.FidToEntityId(a.Fid);
-                            return entityId.HasValue
-                                ? dynamicCounts!.GetValueOrDefault((a.AreaTypeId, entityId.Value), 0)
-                                : 0;
-                        });
-                    }
-                    else if (municipalityCountsByCounty != null)
-                    {
-                        count = g.Sum(a => municipalityCountsByCounty.GetValueOrDefault(a.Fid, 0));
-                    }
-                    else
-                    {
-                        count = g.Sum(a => a.ObservationCount ?? 0);
-                    }
+                    var count = countResolver(g);
 
                     return new AreaMarkerDto
                     {
@@ -534,9 +571,38 @@ public class SearchRepository : ISearchRepository
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            _logger.LogError(ex, "Error retrieving areas for zoom level: {ZoomLevel}", zoomLevel);
+            _logger.LogError(ex, "Feil ved henting av områder for zoomnivå: {ZoomLevel}", zoomLevel);
             throw new ApplicationException(
-                "An error occurred while retrieving areas. Please try again later.", ex);
+                "En feil oppstod ved henting av områder. Prøv igjen senere.", ex);
+        }
+    }
+
+    public async Task<IEnumerable<AreaCountDto>> GetAreaCountsAsync(int zoomLevel, LocationSearchFilterDto? filter = null, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var areas = await LoadAreasForZoomLevel(zoomLevel, filter, cancellationToken);
+            var (filteredAreas, countResolver) = await FilterAndComputeCounts(areas, filter, cancellationToken);
+
+            return filteredAreas
+                .GroupBy(a => a.Fid)
+                .Select(g =>
+                {
+                    var count = countResolver(g);
+                    return new AreaCountDto
+                    {
+                        Fid = g.Key,
+                        ObservationCount = count
+                    };
+                })
+                .Where(a => a.ObservationCount > 0)
+                .ToList();
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogError(ex, "Feil ved henting av områdeantall for zoomnivå: {ZoomLevel}", zoomLevel);
+            throw new ApplicationException(
+                "En feil oppstod ved henting av områdeantall. Prøv igjen senere.", ex);
         }
     }
 

--- a/Artskart3.Tests.Integration/Tests/SearchEndpointTests.cs
+++ b/Artskart3.Tests.Integration/Tests/SearchEndpointTests.cs
@@ -237,4 +237,48 @@ public class SearchEndpointTests : IAsyncLifetime
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
+
+    // -----------------------------------------------------------------------
+    // POST /api/Search/AreaCounts
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetAreaCounts_WithZoomLevel1_Returns200WithJsonArrayAndETag()
+    {
+        var response = await _client.PostAsJsonAsync("/api/Search/AreaCounts?zoomLevel=1", new { });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be("application/json");
+        response.Headers.ETag.Should().NotBeNull();
+
+        var json = await response.Content.ReadAsStringAsync();
+        var doc = JsonDocument.Parse(json);
+        doc.RootElement.ValueKind.Should().Be(JsonValueKind.Array);
+    }
+
+    [Fact]
+    public async Task GetAreaCounts_WithInvalidZoomLevel_Returns400()
+    {
+        var response = await _client.PostAsJsonAsync("/api/Search/AreaCounts?zoomLevel=3", new { });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task GetAreaCounts_WithMatchingETag_Returns304()
+    {
+        var first = await _client.PostAsJsonAsync("/api/Search/AreaCounts?zoomLevel=1", new { });
+        first.StatusCode.Should().Be(HttpStatusCode.OK);
+        var etag = first.Headers.ETag?.Tag;
+        etag.Should().NotBeNullOrEmpty();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, "/api/Search/AreaCounts?zoomLevel=1")
+        {
+            Content = JsonContent.Create(new { }),
+        };
+        request.Headers.TryAddWithoutValidation("If-None-Match", etag!);
+
+        var second = await _client.SendAsync(request);
+        second.StatusCode.Should().Be(HttpStatusCode.NotModified);
+    }
 }

--- a/Artskart3.Tests.Unit/LookupControllerTests.cs
+++ b/Artskart3.Tests.Unit/LookupControllerTests.cs
@@ -85,9 +85,11 @@ public class LookupControllerTests
     {
         var areaResponse = new AreaResponseDto
         {
-            Counties = new CountyDto
+            Counties = new AreaTypeDto
             {
-                FastlandsNorge = [new AreaDto { Id = 1, Fid = "03", Name = "Oslo", IsCurrent = true, ObservationCount = 500 }]
+                Id = 1,
+                Name = "Fylke",
+                Areas = [new AreaDto { Id = 1, Fid = "03", Name = "Oslo", IsCurrent = true, ObservationCount = 500 }]
             },
             Municipalities = new AreaTypeDto
             {

--- a/Artskart3.Tests.Unit/LookupServiceTests.cs
+++ b/Artskart3.Tests.Unit/LookupServiceTests.cs
@@ -85,7 +85,7 @@ public class LookupServiceTests
         var result = await _sut.GetAreasAsync();
 
         result.Municipalities.Should().BeEquivalentTo(municipalityType);
-        result.Counties!.FastlandsNorge.Should().ContainSingle().Which.Fid.Should().Be("03");
+        result.Counties.Should().BeEquivalentTo(countyType);
     }
 
     [Fact]
@@ -97,7 +97,7 @@ public class LookupServiceTests
 
         result.Should().NotBeNull();
         result.Municipalities.Should().BeNull();
-        result.Counties!.FastlandsNorge.Should().BeNullOrEmpty();
+        result.Counties.Should().BeNull();
     }
 
     [Fact]

--- a/Artskart3.Tests.Unit/SearchControllerTests.cs
+++ b/Artskart3.Tests.Unit/SearchControllerTests.cs
@@ -198,4 +198,61 @@ public class SearchControllerTests
         await act.Should().ThrowAsync<Exception>();
     }
 
+    // -----------------------------------------------------------------------
+    // GetAreaCounts
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetAreaCounts_WithInvalidZoomLevel_ReturnsBadRequest()
+    {
+        var result = await _sut.GetAreaCounts(zoomLevel: 3);
+
+        result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task GetAreaCounts_ReturnsCountsWithETag()
+    {
+        var counts = new[] { new AreaCountDto { Fid = "03", ObservationCount = 100 } };
+        _serviceMock
+            .Setup(s => s.GetAreaCountsAsync(1, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AreaCountsResultDto(counts, "\"abc123\""));
+
+        var result = await _sut.GetAreaCounts(zoomLevel: 1);
+
+        var okResult = result.Should().BeOfType<OkObjectResult>().Subject;
+        (okResult.Value as AreaCountDto[]).Should().HaveCount(1);
+        _sut.HttpContext.Response.Headers.ETag.ToString().Should().Be("\"abc123\"");
+    }
+
+    [Fact]
+    public async Task GetAreaCounts_WithMatchingETag_Returns304()
+    {
+        var counts = new[] { new AreaCountDto { Fid = "03", ObservationCount = 100 } };
+        _serviceMock
+            .Setup(s => s.GetAreaCountsAsync(1, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AreaCountsResultDto(counts, "\"abc123\""));
+
+        _sut.HttpContext.Request.Headers["If-None-Match"] = "\"abc123\"";
+
+        var result = await _sut.GetAreaCounts(zoomLevel: 1);
+
+        var statusResult = result.Should().BeOfType<StatusCodeResult>().Subject;
+        statusResult.StatusCode.Should().Be(304);
+    }
+
+    [Fact]
+    public async Task GetAreaCounts_WithNonMatchingETag_Returns200()
+    {
+        var counts = new[] { new AreaCountDto { Fid = "03", ObservationCount = 100 } };
+        _serviceMock
+            .Setup(s => s.GetAreaCountsAsync(1, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AreaCountsResultDto(counts, "\"abc123\""));
+
+        _sut.HttpContext.Request.Headers["If-None-Match"] = "\"old-etag\"";
+
+        var result = await _sut.GetAreaCounts(zoomLevel: 1);
+
+        result.Should().BeOfType<OkObjectResult>();
+    }
 }

--- a/Artskart3.Tests.Unit/SearchServiceTests.cs
+++ b/Artskart3.Tests.Unit/SearchServiceTests.cs
@@ -131,4 +131,86 @@ public class SearchServiceTests
         result.Should().HaveCount(100000);
         result.Should().BeEquivalentTo(largeDataSet);
     }
+
+    // -----------------------------------------------------------------------
+    // GetAreaCountsAsync
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetAreaCountsAsync_WithoutFilters_DerivesCountsFromCachedMarkers()
+    {
+        var markers = new List<AreaMarkerDto>
+        {
+            new() { Fid = "03", ObservationCount = 100 },
+            new() { Fid = "11", ObservationCount = 200 },
+        };
+        _repositoryMock
+            .Setup(r => r.GetAreaMarkersAsync(1, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(markers);
+
+        var result = await _sut.GetAreaCountsAsync(1);
+
+        result.Counts.Should().HaveCount(2);
+        result.Counts.Should().Contain(c => c.Fid == "03" && c.ObservationCount == 100);
+        result.Counts.Should().Contain(c => c.Fid == "11" && c.ObservationCount == 200);
+        result.Etag.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task GetAreaCountsAsync_WithoutFilters_CachesResultOnSecondCall()
+    {
+        var markers = new List<AreaMarkerDto>
+        {
+            new() { Fid = "03", ObservationCount = 100 },
+        };
+        _repositoryMock
+            .Setup(r => r.GetAreaMarkersAsync(1, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(markers);
+
+        var first = await _sut.GetAreaCountsAsync(1);
+        var second = await _sut.GetAreaCountsAsync(1);
+
+        first.Etag.Should().Be(second.Etag);
+        // Markør-repository kalles kun én gang (cachet av GetAreaMarkersAsync)
+        _repositoryMock.Verify(r => r.GetAreaMarkersAsync(1, null, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetAreaCountsAsync_WithFilters_DelegatesToRepository()
+    {
+        var filter = new LocationSearchFilterDto { TaxonGroupIds = [1] };
+        var counts = new List<AreaCountDto>
+        {
+            new() { Fid = "03", ObservationCount = 50 },
+        };
+        _repositoryMock
+            .Setup(r => r.GetAreaCountsAsync(1, filter, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(counts);
+
+        var result = await _sut.GetAreaCountsAsync(1, filter);
+
+        result.Counts.Should().HaveCount(1);
+        result.Counts[0].Fid.Should().Be("03");
+        _repositoryMock.Verify(r => r.GetAreaCountsAsync(1, filter, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetAreaCountsAsync_WithSameFilter_ReturnsCachedResult()
+    {
+        var filter = new LocationSearchFilterDto { TaxonGroupIds = [1] };
+        var counts = new List<AreaCountDto>
+        {
+            new() { Fid = "03", ObservationCount = 50 },
+        };
+        _repositoryMock
+            .Setup(r => r.GetAreaCountsAsync(1, It.IsAny<LocationSearchFilterDto>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(counts);
+
+        var first = await _sut.GetAreaCountsAsync(1, filter);
+        var second = await _sut.GetAreaCountsAsync(1, filter);
+
+        first.Etag.Should().Be(second.Etag);
+        // Repository kalles kun én gang — andre kall er cachet
+        _repositoryMock.Verify(r => r.GetAreaCountsAsync(1, It.IsAny<LocationSearchFilterDto>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
 }

--- a/Artskart3.WebApp/README.md
+++ b/Artskart3.WebApp/README.md
@@ -54,6 +54,51 @@ ng e2e
 
 Angular CLI does not come with an end-to-end testing framework by default. You can choose one that suits your needs.
 
+## Caching av kartdata
+
+Kartkomponenten bruker en flernivå caching-strategi for å minimere nettverkstrafikk og gi umiddelbar respons ved filter- og zoomendringer.
+
+### Geometri-cache (`geometryCacheByApiZoom`)
+
+- Lagrer `AreaMarkerDto[]` (polygoner, centroider, navn) per API-zoomnivå (1 = fylker, 2 = kommuner).
+- Fylles ved oppstart via `prefetchAreaGeometries()` som henter fylker først, deretter kommuner i bakgrunnen.
+- **Tømmes aldri** under sesjonen — geometrier endres svært sjelden.
+- Zoomnivå 1 inkluderer også havområder og Svalbard/Bjørnøya/Jan Mayen-geometrier.
+
+### Antall-cache (`countsCacheByApiZoom`)
+
+- Lagrer `{ counts: Map<fid, antall>, etag: string | null, unrestricted: boolean }` per zoomnivå.
+- `unrestricted`-flagget indikerer om antallene dekker alle områder (`true`) eller kun et utvalg (`false`).
+- **Tømmes når attributtfiltre endres** (taksongruppe, kategori, periode, etc.) fordi disse påvirker antall per område.
+- **Beholdes ved områdevalg-endringer** — bruker `unrestricted`-flagget for å avgjøre om cachede verdier dekker de nødvendige områdene.
+
+### ETag-støtte
+
+- Backend-endepunktet `POST /api/Search/AreaCounts` returnerer en ETag-header basert på MD5-hash av responsen.
+- Frontend sender `If-None-Match` ved etterfølgende forespørsler. Ved treff returnerer backend `304 Not Modified` uten data.
+- Backend cacher resultater (antall + ETag) i `IMemoryCache` med en nøkkel basert på SHA256-hash av filteret. TTL er 5 minutter. Dette betyr at gjentatte forespørsler med samme filter hopper over databasespørringen helt.
+
+### Enhetlig oppdatering (`rebuildAllLayers`)
+
+All oppdatering av kartlag skjer gjennom én funksjon: `rebuildAllLayers()`. Den kalles ved:
+- Filterendringer (via `_onFilterChange`-effekten)
+- Kamerabevegelser (debounced med 150ms via `cameraChanged$`)
+- Fullført prefetch av geometrier
+
+Funksjonen oppdaterer alltid **begge** områdelag (fylker og kommuner) samt overlay-laget, og sikrer at ingen lag viser foreldede data uavhengig av zoom- eller filterrekkefølge.
+
+### Overlay-lag
+
+Et eget ikke-klikkbart kartlag (`area-overlay-selected`) viser omrissene av valgte områder uavhengig av zoomnivå. Det inkluderer:
+- Valgte fylker og havområder
+- Foreldrefylker til valgte kommuner (for kontekst)
+- Valgte kommuner
+
+## Kjente forbedringspunkter
+
+- **Listevisningen henter data når den ikke er aktiv**: `list-view.component` trigger `api/Search/Observation`-kall ved filterendringer selv når listfanen ikke er synlig. Bør undersøkes for å unngå unødvendige backend-kall.
+- **Service Worker for geometri-caching**: Geometridata (WKT-polygoner for fylker og kommuner) er store og endres sjelden. En Service Worker med Cache API kan lagre disse på tvers av sidelastinger, slik at prefetch-kallene ved oppstart unngås. Dette vil redusere initial lastetid med ca. 1-5 MB i nettverkstrafikk.
+
 ## Additional Resources
 
 For more information on using the Angular CLI, including detailed command references, visit the [Angular CLI Overview and Command Reference](https://angular.dev/tools/cli) page.

--- a/Artskart3.WebApp/README.md
+++ b/Artskart3.WebApp/README.md
@@ -67,10 +67,14 @@ Kartkomponenten bruker en flernivå caching-strategi for å minimere nettverkstr
 
 ### Antall-cache (`countsCacheByApiZoom`)
 
-- Lagrer `{ counts: Map<fid, antall>, etag: string | null, unrestricted: boolean }` per zoomnivå.
-- `unrestricted`-flagget indikerer om antallene dekker alle områder (`true`) eller kun et utvalg (`false`).
+- Lagrer `{ counts: Map<fid, antall>, etag: string | null, selectionKey: string }` per zoomnivå.
+- `selectionKey` identifiserer hvilket områdevalg (fylker, kommuner, havområder) antallene ble hentet for.
 - **Tømmes når attributtfiltre endres** (taksongruppe, kategori, periode, etc.) fordi disse påvirker antall per område.
-- **Beholdes ved områdevalg-endringer** — bruker `unrestricted`-flagget for å avgjøre om cachede verdier dekker de nødvendige områdene.
+- **Beholdes ved områdevalg-endringer** — cachede verdier brukes kun når `selectionKey` er uendret. Områder som mangler i responsen tolkes som 0 (backend utelater områder uten treff).
+
+### Havområder og Svalbard/Bjørnøya/Jan Mayen
+
+Disse områdene hører ikke til et bestemt zoomnivå og leveres kun med zoomnivå 1. De kopieres derfor inn i geometri-cachen for zoomnivå 2 (`withCrossLevelAreas`), slik at de vises i begge områdelag — også når kommunevalg gjør at fylkeslaget tegnes fra kommunedata.
 
 ### ETag-støtte
 
@@ -78,8 +82,11 @@ Kartkomponenten bruker en flernivå caching-strategi for å minimere nettverkstr
 - Frontend sender `If-None-Match` ved etterfølgende forespørsler. Ved treff returnerer backend `304 Not Modified` uten data.
 - Backend cacher resultater (antall + ETag) i `IMemoryCache` med en nøkkel basert på SHA256-hash av filteret. TTL er 5 minutter. Dette betyr at gjentatte forespørsler med samme filter hopper over databasespørringen helt.
 
-### Enhetlig oppdatering (`rebuildAllLayers`)
+### Hvilke områder vises (`mergeCountsIntoAreas`)
 
+Alle kartlag bruker samme regel: et område tegnes når det har treff, eller når det er eksplisitt valgt av brukeren. Valgte områder uten treff vises med «0», slik at brukeren ser at valget ga null resultater. Områder som kun er med fordi de ligger i et valgt fylke, skjules når de har 0 treff.
+
+### Enhetlig oppdatering (`rebuildAllLayers`)
 All oppdatering av kartlag skjer gjennom én funksjon: `rebuildAllLayers()`. Den kalles ved:
 - Filterendringer (via `_onFilterChange`-effekten)
 - Kamerabevegelser (debounced med 150ms via `cameraChanged$`)

--- a/Artskart3.WebApp/src/app/core/services/api-client.service.spec.ts
+++ b/Artskart3.WebApp/src/app/core/services/api-client.service.spec.ts
@@ -1,0 +1,93 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { ApiClientService } from './api-client.service';
+
+describe('ApiClientService', () => {
+  let service: ApiClientService;
+  let httpMock: HttpTestingController;
+  const endpoint = '/api/Search/AreaCounts?zoomLevel=1';
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [ApiClientService, provideHttpClient(), provideHttpClientTesting()],
+    });
+    service = TestBed.inject(ApiClientService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  describe('postJsonWithETag', () => {
+    it('should send If-None-Match when an etag is provided', () => {
+      service.postJsonWithETag(endpoint, {}, '"abc123"').subscribe();
+
+      const req = httpMock.expectOne(endpoint);
+      expect(req.request.headers.get('If-None-Match')).toBe('"abc123"');
+      req.flush([]);
+    });
+
+    it('should not send If-None-Match when no etag is provided', () => {
+      service.postJsonWithETag(endpoint, {}).subscribe();
+
+      const req = httpMock.expectOne(endpoint);
+      expect(req.request.headers.has('If-None-Match')).toBe(false);
+      req.flush([]);
+    });
+
+    it('should return body and etag for a 200 response', () => {
+      let result: { body: unknown; etag: string | null; notModified: boolean } | undefined;
+      service.postJsonWithETag(endpoint, {}).subscribe(r => (result = r));
+
+      httpMock.expectOne(endpoint).flush([{ fid: '03', observationCount: 5 }], {
+        headers: { ETag: '"abc123"' },
+      });
+
+      expect(result).toEqual({
+        body: [{ fid: '03', observationCount: 5 }],
+        etag: '"abc123"',
+        notModified: false,
+      });
+    });
+
+    it('should resolve a 304 without retrying', () => {
+      let result: { body: unknown; etag: string | null; notModified: boolean } | undefined;
+      service.postJsonWithETag(endpoint, {}, '"abc123"').subscribe(r => (result = r));
+
+      httpMock
+        .expectOne(endpoint)
+        .flush(null, { status: 304, statusText: 'Not Modified', headers: { ETag: '"abc123"' } });
+
+      expect(result).toEqual({ body: null, etag: '"abc123"', notModified: true });
+      // Ingen ytterligere forespørsler — 304 skal ikke gå gjennom retry
+      httpMock.expectNone(endpoint);
+    });
+
+    it('should fall back to the request etag when the 304 has no ETag header', () => {
+      let result: { body: unknown; etag: string | null; notModified: boolean } | undefined;
+      service.postJsonWithETag(endpoint, {}, '"abc123"').subscribe(r => (result = r));
+
+      httpMock.expectOne(endpoint).flush(null, { status: 304, statusText: 'Not Modified' });
+
+      expect(result).toEqual({ body: null, etag: '"abc123"', notModified: true });
+    });
+
+    it('should still retry server errors', async () => {
+      vi.useFakeTimers();
+      let result: { body: unknown; etag: string | null; notModified: boolean } | undefined;
+      service.postJsonWithETag(endpoint, {}).subscribe(r => (result = r));
+
+      httpMock
+        .expectOne(endpoint)
+        .flush(null, { status: 503, statusText: 'Service Unavailable' });
+      await vi.advanceTimersByTimeAsync(1000);
+
+      httpMock.expectOne(endpoint).flush([], { headers: { ETag: '"abc123"' } });
+
+      expect(result).toEqual({ body: [], etag: '"abc123"', notModified: false });
+      vi.useRealTimers();
+    });
+  });
+});

--- a/Artskart3.WebApp/src/app/core/services/api-client.service.ts
+++ b/Artskart3.WebApp/src/app/core/services/api-client.service.ts
@@ -4,9 +4,9 @@
  */
 
 import { Injectable, inject } from '@angular/core';
-import { HttpClient, HttpErrorResponse } from '@angular/common/http';
-import { Observable, throwError } from 'rxjs';
-import { catchError, retry } from 'rxjs/operators';
+import { HttpClient, HttpErrorResponse, HttpHeaders } from '@angular/common/http';
+import { Observable, of, throwError } from 'rxjs';
+import { catchError, map, retry } from 'rxjs/operators';
 import { ApiMessages, RetryConfig } from '@core/constants/api-messages';
 import { LoggingService } from '@shared/logging.service';
 
@@ -49,6 +49,39 @@ export class ApiClientService {
         count: RetryConfig.MaxAttempts - 1
       }),
       catchError(error => this.handleError(error, `Failed to post ${endpoint}`))
+    );
+  }
+
+  postJsonWithETag<T>(
+    endpoint: string,
+    body: unknown,
+    etag?: string,
+  ): Observable<{ body: T | null; etag: string | null; notModified: boolean }> {
+    let headers = new HttpHeaders();
+    if (etag) {
+      headers = headers.set('If-None-Match', etag);
+    }
+
+    return this.http.post<T>(endpoint, body, { headers, observe: 'response' }).pipe(
+      retry({
+        delay: RetryConfig.InitialDelayMs,
+        count: RetryConfig.MaxAttempts - 1,
+      }),
+      map(response => ({
+        body: response.body,
+        etag: response.headers.get('ETag'),
+        notModified: false,
+      })),
+      catchError((error: HttpErrorResponse) => {
+        if (error.status === 304) {
+          return of({
+            body: null as T | null,
+            etag: etag ?? null,
+            notModified: true,
+          });
+        }
+        return this.handleError(error, `Failed to post ${endpoint}`);
+      }),
     );
   }
 

--- a/Artskart3.WebApp/src/app/core/services/api-client.service.ts
+++ b/Artskart3.WebApp/src/app/core/services/api-client.service.ts
@@ -4,11 +4,18 @@
  */
 
 import { Injectable, inject } from '@angular/core';
-import { HttpClient, HttpErrorResponse, HttpHeaders } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse, HttpHeaders, HttpResponse } from '@angular/common/http';
 import { Observable, of, throwError } from 'rxjs';
 import { catchError, map, retry } from 'rxjs/operators';
 import { ApiMessages, RetryConfig } from '@core/constants/api-messages';
 import { LoggingService } from '@shared/logging.service';
+
+const HTTP_STATUS_NOT_MODIFIED = 304;
+
+/**
+ * Markerer en 304-respons internt, slik at den ikke behandles som en feil av retry.
+ */
+const NOT_MODIFIED = Symbol('NotModified');
 
 @Injectable({
   providedIn: 'root'
@@ -63,25 +70,30 @@ export class ApiClientService {
     }
 
     return this.http.post<T>(endpoint, body, { headers, observe: 'response' }).pipe(
+      // 304 er et gyldig svar, ikke en feil — håndteres før retry så den ikke prøves på nytt
+      catchError((error: HttpErrorResponse) =>
+        error.status === HTTP_STATUS_NOT_MODIFIED
+          ? of({ marker: NOT_MODIFIED, etag: error.headers.get('ETag') } as const)
+          : throwError(() => error),
+      ),
       retry({
         delay: RetryConfig.InitialDelayMs,
         count: RetryConfig.MaxAttempts - 1,
       }),
-      map(response => ({
-        body: response.body,
-        etag: response.headers.get('ETag'),
-        notModified: false,
-      })),
-      catchError((error: HttpErrorResponse) => {
-        if (error.status === 304) {
-          return of({
-            body: null as T | null,
-            etag: etag ?? null,
-            notModified: true,
-          });
-        }
-        return this.handleError(error, `Failed to post ${endpoint}`);
-      }),
+      map(response =>
+        response instanceof HttpResponse
+          ? {
+              body: response.body,
+              etag: response.headers.get('ETag'),
+              notModified: false,
+            }
+          : {
+              body: null as T | null,
+              etag: response.etag ?? etag ?? null,
+              notModified: true,
+            },
+      ),
+      catchError((error: HttpErrorResponse) => this.handleError(error, `Failed to post ${endpoint}`)),
     );
   }
 

--- a/Artskart3.WebApp/src/app/core/services/areas/areas.service.ts
+++ b/Artskart3.WebApp/src/app/core/services/areas/areas.service.ts
@@ -270,6 +270,11 @@ function calculateClippedCentroid(parsed: ParsedGeometry, extent: [number, numbe
   return ensureInsideRing([largest.cx, largest.cy], largest.ring);
 }
 
+export interface AreaCountDto {
+  fid: string;
+  observationCount: number;
+}
+
 export interface LocationSearchFilter {
   categoryIds?: number[];
   organizationIds?: number[];
@@ -304,6 +309,7 @@ export class AreasService {
   private readonly validationService: ValidationService = inject(ValidationService);
 
   private readonly areasBaseEndpoint = '/api/Search/AreaMarkers';
+  private readonly areaCountsEndpoint = '/api/Search/AreaCounts';
   private readonly locationsEndpoint = '/api/Search/Locations';
   private readonly locationPolygonsEndpoint = '/api/Search/LocationPolygons';
 
@@ -396,6 +402,60 @@ export class AreasService {
     };
   }
 
+  /**
+   * Henter observasjonsantall per område uten geometri, med ETag-støtte.
+   */
+  getAreaCounts(
+    apiZoomLevel: number,
+    filter?: LocationSearchFilter,
+    etag?: string,
+  ): Observable<{ counts: AreaCountDto[] | null; etag: string | null; notModified: boolean }> {
+    const body = this.buildFilterBody(filter);
+
+    return this.apiClientService
+      .postJsonWithETag<AreaCountDto[]>(`${this.areaCountsEndpoint}?zoomLevel=${apiZoomLevel}`, body, etag)
+      .pipe(
+        map(response => ({
+          counts: response.body ?? null,
+          etag: response.etag,
+          notModified: response.notModified,
+        })),
+      );
+  }
+
+  /**
+   * Bygger GeoJSON-features med kun polygon-omriss for valgte områder (ingen centroid-markører).
+   */
+  buildOverlayFeatures(areas: AreaMarkerDto[], selectedFids: string[]): unknown[] {
+    if (!selectedFids.length || !areas.length) return [];
+
+    const fidSet = new Set(selectedFids);
+    const features: unknown[] = [];
+
+    for (const area of areas) {
+      if (!fidSet.has(area.fid)) continue;
+      const parsed = parseWkt(area.wktsPolygon);
+      if (!parsed) continue;
+
+      features.push({
+        type: 'Feature',
+        geometry: { type: parsed.type, coordinates: parsed.coordinates },
+        properties: {
+          id: area.id,
+          name: area.name,
+          fid: area.fid,
+          'nbic:style': {
+            strokeColor: 'rgba(10, 109, 188, 0.6)',
+            strokeWidth: 1.5,
+            fillColor: 'rgba(0, 0, 0, 0)',
+          },
+        },
+      });
+    }
+
+    return features;
+  }
+
   private buildFilterBody(filter?: LocationSearchFilter, extent?: [number, number, number, number]): Record<string, unknown> {
     const body: Record<string, unknown> = {};
 
@@ -482,7 +542,7 @@ export class AreasService {
       if (!this.bboxOverlaps(bbox, extent)) continue;
 
       const count = area.observationCount ?? 0;
-      const formattedCount = count > 0 ? AbbreviateNumberHelper.format(count) : '';
+      const formattedCount = count > 0 ? AbbreviateNumberHelper.format(count) : '0';
 
       // Bruk DB-centroid når hele området er synlig, ellers beregn centroid av synlig del
       const fullyVisible = bbox[0] >= extent[0] && bbox[1] >= extent[1]

--- a/Artskart3.WebApp/src/app/core/services/areas/areas.service.ts
+++ b/Artskart3.WebApp/src/app/core/services/areas/areas.service.ts
@@ -542,7 +542,7 @@ export class AreasService {
       if (!this.bboxOverlaps(bbox, extent)) continue;
 
       const count = area.observationCount ?? 0;
-      const formattedCount = count > 0 ? AbbreviateNumberHelper.format(count) : '0';
+      const formattedCount = AbbreviateNumberHelper.format(count);
 
       // Bruk DB-centroid når hele området er synlig, ellers beregn centroid av synlig del
       const fullyVisible = bbox[0] >= extent[0] && bbox[1] >= extent[1]

--- a/Artskart3.WebApp/src/app/shared/components/map.component/map.component.spec.ts
+++ b/Artskart3.WebApp/src/app/shared/components/map.component/map.component.spec.ts
@@ -8,6 +8,7 @@ import { MapComponent } from './map.component';
 import { MapToolbarComponent } from './map-toolbar/map-toolbar.component';
 import { ApiZoomLevel } from './map.types';
 import { AreasService } from '@core/services/areas/areas.service';
+import { FilterStateService } from '@shared/services/filter-state/filter-state.service';
 
 describe('MapComponent', () => {
   let component: MapComponent;
@@ -138,6 +139,186 @@ describe('MapComponent', () => {
       );
 
       vi.useRealTimers();
+    });
+  });
+
+  describe('geometry and counts caching', () => {
+    const AREA_TYPE_COUNTY = 2;
+    const AREA_TYPE_MUNICIPALITY = 1;
+    const AREA_TYPE_OCEAN = 4;
+
+    const area = (fid: string, areaTypeId: number, observationCount = 0) => ({
+      id: Number(fid.replace(/\D/g, '')) || 1,
+      documentId: fid,
+      fid,
+      name: `Area ${fid}`,
+      areaTypeId,
+      parentFid: '',
+      syncDateTime: '',
+      timeStamp: '',
+      isCurrent: true,
+      observationCount,
+      wktsPolygon: 'POLYGON((0 0, 0 10, 10 10, 10 0, 0 0))',
+    });
+
+    const accessPrivate = (c: MapComponent) =>
+      c as unknown as {
+        geometryCacheByApiZoom: Map<number, ReturnType<typeof area>[]>;
+        countsCacheByApiZoom: Map<number, { counts: Map<string, number>; etag: string | null; selectionKey: string }>;
+        seedCountsFromGeometries: (apiZoomLevel: number, areas: ReturnType<typeof area>[]) => void;
+        rebuildAreaLayer: (
+          apiZoomLevel: number,
+          filter: Record<string, unknown>,
+          extent: [number, number, number, number],
+          pendingFetches: { dataZoomLevel: number; apiZoomLevel: number }[],
+        ) => void;
+        areaSelectionKey: (filter: Record<string, unknown>) => string;
+      };
+
+    beforeEach(() => {
+      component.map = { updateGeoJSONLayer: vi.fn() } as unknown as NbicMapComponent;
+      const priv = accessPrivate(component);
+      priv.geometryCacheByApiZoom.clear();
+      priv.countsCacheByApiZoom.clear();
+    });
+
+    it('should make ocean areas available in the municipalities geometry cache', () => {
+      const priv = accessPrivate(component);
+      priv.seedCountsFromGeometries(ApiZoomLevel.Counties, [
+        area('03', AREA_TYPE_COUNTY, 100),
+        area('91', AREA_TYPE_OCEAN, 50),
+      ]);
+
+      priv.seedCountsFromGeometries(ApiZoomLevel.Municipalities, [area('0301', AREA_TYPE_MUNICIPALITY, 100)]);
+
+      const municipalityGeometries = priv.geometryCacheByApiZoom.get(ApiZoomLevel.Municipalities) ?? [];
+      expect(municipalityGeometries.map(a => a.fid)).toEqual(['0301', '91']);
+    });
+
+    it('should not duplicate ocean areas already present at the municipality level', () => {
+      const priv = accessPrivate(component);
+      priv.seedCountsFromGeometries(ApiZoomLevel.Counties, [area('91', AREA_TYPE_OCEAN, 50)]);
+
+      priv.seedCountsFromGeometries(ApiZoomLevel.Municipalities, [
+        area('0301', AREA_TYPE_MUNICIPALITY, 100),
+        area('91', AREA_TYPE_OCEAN, 50),
+      ]);
+
+      const fids = (priv.geometryCacheByApiZoom.get(ApiZoomLevel.Municipalities) ?? []).map(a => a.fid);
+      expect(fids).toEqual(['0301', '91']);
+    });
+
+    it('should render selected areas with zero counts from cache without refetching', () => {
+      const priv = accessPrivate(component);
+      const filterState = TestBed.inject(FilterStateService);
+      filterState.selectedCategoryIds.set([1]);
+
+      const filter = { oceanAreaIds: ['91'], municipalityIds: ['0301'] };
+      priv.geometryCacheByApiZoom.set(ApiZoomLevel.Municipalities, [
+        area('0301', AREA_TYPE_MUNICIPALITY),
+        area('91', AREA_TYPE_OCEAN),
+      ]);
+      // Backend utelater områder uten treff — '91' mangler bevisst
+      priv.countsCacheByApiZoom.set(ApiZoomLevel.Municipalities, {
+        counts: new Map([['0301', 5]]),
+        etag: null,
+        selectionKey: priv.areaSelectionKey(filter),
+      });
+
+      const pendingFetches: { dataZoomLevel: number; apiZoomLevel: number }[] = [];
+      priv.rebuildAreaLayer(ApiZoomLevel.Municipalities, filter, [0, 0, 1000000, 1000000], pendingFetches);
+
+      expect(pendingFetches).toEqual([]);
+      filterState.selectedCategoryIds.set([]);
+    });
+
+    it('should refetch counts when the area selection changes', () => {
+      const priv = accessPrivate(component);
+      const filterState = TestBed.inject(FilterStateService);
+      filterState.selectedCategoryIds.set([1]);
+
+      priv.geometryCacheByApiZoom.set(ApiZoomLevel.Municipalities, [area('0301', AREA_TYPE_MUNICIPALITY)]);
+      priv.countsCacheByApiZoom.set(ApiZoomLevel.Municipalities, {
+        counts: new Map([['0301', 5]]),
+        etag: null,
+        selectionKey: priv.areaSelectionKey({ municipalityIds: ['0301'] }),
+      });
+
+      const pendingFetches: { dataZoomLevel: number; apiZoomLevel: number }[] = [];
+      priv.rebuildAreaLayer(ApiZoomLevel.Municipalities, { municipalityIds: ['0302'] }, [0, 0, 1000000, 1000000], pendingFetches);
+
+      expect(pendingFetches).toEqual([
+        { dataZoomLevel: ApiZoomLevel.Municipalities, apiZoomLevel: ApiZoomLevel.Municipalities },
+      ]);
+      filterState.selectedCategoryIds.set([]);
+    });
+  });
+
+  describe('zero-count area rendering', () => {
+    const AREA_TYPE_MUNICIPALITY = 1;
+
+    const area = (fid: string, observationCount = 0, parentFid = '') => ({
+      id: 1,
+      documentId: fid,
+      fid,
+      name: `Area ${fid}`,
+      areaTypeId: AREA_TYPE_MUNICIPALITY,
+      parentFid,
+      syncDateTime: '',
+      timeStamp: '',
+      isCurrent: true,
+      observationCount,
+      wktsPolygon: 'POLYGON((0 0, 0 10, 10 10, 10 0, 0 0))',
+    });
+
+    const mergeCountsIntoAreas = (
+      c: MapComponent,
+      areas: ReturnType<typeof area>[],
+      counts: Map<string, number>,
+      filter: Record<string, unknown>,
+    ) =>
+      (c as unknown as {
+        mergeCountsIntoAreas: (
+          a: ReturnType<typeof area>[],
+          counts: Map<string, number>,
+          f: Record<string, unknown>,
+        ) => ReturnType<typeof area>[];
+      }).mergeCountsIntoAreas(areas, counts, filter);
+
+    it('should hide unselected areas without observations', () => {
+      const result = mergeCountsIntoAreas(
+        component,
+        [area('0301'), area('0302')],
+        new Map([['0301', 7]]),
+        {},
+      );
+
+      expect(result.map(a => a.fid)).toEqual(['0301']);
+    });
+
+    it('should keep explicitly selected areas with zero observations', () => {
+      const result = mergeCountsIntoAreas(
+        component,
+        [area('0301'), area('91')],
+        new Map([['0301', 7]]),
+        { municipalityIds: ['0301'], oceanAreaIds: ['91'] },
+      );
+
+      expect(result.map(a => ({ fid: a.fid, count: a.observationCount }))).toEqual([
+        { fid: '0301', count: 7 },
+        { fid: '91', count: 0 },
+      ]);
+    });
+
+    it('should hide zero-count children of a selected county', () => {
+      const result = mergeCountsIntoAreas(
+        component,
+        [area('0301', 0, '03'), area('0302', 0, '03')],
+        new Map([['0302', 4]]),
+        { countyIds: ['03'] },
+      );
+
+      expect(result.map(a => a.fid)).toEqual(['0302']);
     });
   });
 });

--- a/Artskart3.WebApp/src/app/shared/components/map.component/map.component.spec.ts
+++ b/Artskart3.WebApp/src/app/shared/components/map.component/map.component.spec.ts
@@ -82,14 +82,15 @@ describe('MapComponent', () => {
   describe('counts fetch pipeline error resilience', () => {
     let areasService: AreasService;
     let updateGeoJSONLayerSpy: ReturnType<typeof vi.fn>;
-    let fetchCounts$: Subject<{ dataZoomLevel: number; apiZoomLevel: number; extent: [number, number, number, number] }>;
+    let fetchCounts$: Subject<{ requests: { dataZoomLevel: number; apiZoomLevel: number }[]; extent: [number, number, number, number] }>;
     let locationsFetch$: Subject<{ extent: [number, number, number, number]; filter: unknown }>;
 
     const accessPrivate = (c: MapComponent) =>
       c as unknown as {
-        fetchCounts$: Subject<{ dataZoomLevel: number; apiZoomLevel: number; extent: [number, number, number, number] }>;
+        fetchCounts$: Subject<{ requests: { dataZoomLevel: number; apiZoomLevel: number }[]; extent: [number, number, number, number] }>;
         locationsFetch$: Subject<{ extent: [number, number, number, number]; filter: unknown }>;
         setupCountsFetchPipeline: () => void;
+        setupLocationsFetchPipeline: () => void;
         geometryCacheByApiZoom: Map<number, unknown[]>;
         countsCacheByApiZoom: Map<number, unknown>;
       };
@@ -105,6 +106,7 @@ describe('MapComponent', () => {
       priv.geometryCacheByApiZoom.clear();
       priv.countsCacheByApiZoom.clear();
       priv.setupCountsFetchPipeline();
+      priv.setupLocationsFetchPipeline();
     });
 
     it('should continue processing after a service error', () => {
@@ -118,7 +120,7 @@ describe('MapComponent', () => {
         throwError(() => new Error('503 Service Unavailable'))
       );
 
-      fetchCounts$.next({ dataZoomLevel: ApiZoomLevel.Municipalities, apiZoomLevel: ApiZoomLevel.Municipalities, extent: testExtent });
+      fetchCounts$.next({ requests: [{ dataZoomLevel: ApiZoomLevel.Municipalities, apiZoomLevel: ApiZoomLevel.Municipalities }], extent: testExtent });
       vi.advanceTimersByTime(300);
 
       expect(updateGeoJSONLayerSpy).not.toHaveBeenCalled();

--- a/Artskart3.WebApp/src/app/shared/components/map.component/map.component.spec.ts
+++ b/Artskart3.WebApp/src/app/shared/components/map.component/map.component.spec.ts
@@ -79,16 +79,19 @@ describe('MapComponent', () => {
     });
   });
 
-  describe('setupAreaDataPipeline error resilience', () => {
+  describe('counts fetch pipeline error resilience', () => {
     let areasService: AreasService;
     let updateGeoJSONLayerSpy: ReturnType<typeof vi.fn>;
-    let fetchAreaData$: Subject<{ apiZoomLevel: number; olZoom: number; extent: [number, number, number, number] }>;
+    let fetchCounts$: Subject<{ dataZoomLevel: number; apiZoomLevel: number; extent: [number, number, number, number] }>;
+    let locationsFetch$: Subject<{ extent: [number, number, number, number]; filter: unknown }>;
 
     const accessPrivate = (c: MapComponent) =>
       c as unknown as {
-        fetchAreaData$: Subject<{ apiZoomLevel: number; olZoom: number; extent: [number, number, number, number] }>;
-        setupAreaDataPipeline: () => void;
-        areaDataCacheByApiZoom: Map<number, unknown[]>;
+        fetchCounts$: Subject<{ dataZoomLevel: number; apiZoomLevel: number; extent: [number, number, number, number] }>;
+        locationsFetch$: Subject<{ extent: [number, number, number, number]; filter: unknown }>;
+        setupCountsFetchPipeline: () => void;
+        geometryCacheByApiZoom: Map<number, unknown[]>;
+        countsCacheByApiZoom: Map<number, unknown>;
       };
 
     beforeEach(() => {
@@ -97,23 +100,25 @@ describe('MapComponent', () => {
       component.map = { updateGeoJSONLayer: updateGeoJSONLayerSpy } as unknown as NbicMapComponent;
 
       const priv = accessPrivate(component);
-      fetchAreaData$ = priv.fetchAreaData$;
-      priv.areaDataCacheByApiZoom.clear();
-      priv.setupAreaDataPipeline();
+      fetchCounts$ = priv.fetchCounts$;
+      locationsFetch$ = priv.locationsFetch$;
+      priv.geometryCacheByApiZoom.clear();
+      priv.countsCacheByApiZoom.clear();
+      priv.setupCountsFetchPipeline();
     });
 
-    it('should continue processing zoom changes after a service error', () => {
+    it('should continue processing after a service error', () => {
       vi.useFakeTimers();
       const geojson = '{"type":"FeatureCollection","features":[]}';
 
       const testExtent: [number, number, number, number] = [0, 0, 1000000, 1000000];
 
-      // First call fails
+      // First call fails (counts fetch with no cached geometries → falls back to getAreaMarkers)
       vi.spyOn(areasService, 'getAreaMarkers').mockReturnValueOnce(
         throwError(() => new Error('503 Service Unavailable'))
       );
 
-      fetchAreaData$.next({ apiZoomLevel: ApiZoomLevel.Municipalities, olZoom: 10, extent: testExtent });
+      fetchCounts$.next({ dataZoomLevel: ApiZoomLevel.Municipalities, apiZoomLevel: ApiZoomLevel.Municipalities, extent: testExtent });
       vi.advanceTimersByTime(300);
 
       expect(updateGeoJSONLayerSpy).not.toHaveBeenCalled();
@@ -121,7 +126,7 @@ describe('MapComponent', () => {
       // Second call succeeds — pipeline should still be alive
       vi.spyOn(areasService, 'getLocationsAsGeoJsonString').mockReturnValueOnce(of(geojson));
 
-      fetchAreaData$.next({ apiZoomLevel: ApiZoomLevel.LocationPoints, olZoom: 13, extent: testExtent });
+      locationsFetch$.next({ extent: testExtent, filter: {} });
       vi.advanceTimersByTime(300);
 
       expect(updateGeoJSONLayerSpy).toHaveBeenCalledWith(

--- a/Artskart3.WebApp/src/app/shared/components/map.component/map.component.ts
+++ b/Artskart3.WebApp/src/app/shared/components/map.component/map.component.ts
@@ -20,7 +20,7 @@ import { LoggingService } from '@shared/logging.service';
 import { Observable, Subject, EMPTY, merge, concat as rxConcat } from 'rxjs';
 import { catchError, debounceTime, map as rxMap, switchMap, takeUntil, tap } from 'rxjs/operators';
 import { AreasService, LocationSearchFilter } from '@core/services/areas/areas.service';
-import { AreaMarkerDto } from '@shared/models/area/area-marker.model';
+import { AreaMarkerDto, AreaTypeId } from '@shared/models/area/area-marker.model';
 import { ZoomConfig } from '@shared/helpers/zoom/zoom-config';
 import { MAP_CONFIG } from '@shared/config/map.config';
 import { CommonModule } from '@angular/common';
@@ -34,6 +34,14 @@ import { ArtskartZoomControl } from './controls/zoom.control';
 import { ArtskartFullscreenControl } from './controls/fullscreen.control';
 import { createGeolocationControl, GeolocationMapControl } from './controls/geolocation.control';
 import { TranslateService } from '@ngx-translate/core';
+
+/**
+ * Områdetyper som ikke tilhører et bestemt zoomnivå og derfor skal vises i begge områdelag.
+ */
+const CROSS_LEVEL_AREA_TYPES = new Set<number>([
+  AreaTypeId.OceanArea,
+  AreaTypeId.SvalbardBjørnøyaAndJanMayen,
+]);
 
 @Component({
   selector: 'app-map',
@@ -60,11 +68,11 @@ export class MapComponent implements AfterViewInit, OnDestroy {
 
   // Geometri-cache: persistent for hele sesjonen, tømmes aldri ved filterendring
   private geometryCacheByApiZoom = new Map<number, AreaMarkerDto[]>();
-  // Antall-cache: inneholder antall per fid, ETag og om cachen er ufiltrert
+  // Antall-cache: antall per fid, ETag og hvilket områdevalg antallene gjelder for
   private countsCacheByApiZoom = new Map<number, {
     counts: Map<string, number>;
     etag: string | null;
-    unrestricted: boolean;
+    selectionKey: string;
   }>();
   private mapReady = false;
   // Sporer forrige attributtfilter for å oppdage endringer som krever refetch
@@ -423,23 +431,18 @@ export class MapComponent implements AfterViewInit, OnDestroy {
     }
 
     if (!this.hasActiveAttributeFilters()) {
-      const filtered = this.filterCachedAreasBySelection(cachedGeometries, filter);
-      const geojson = this.areasService.buildAreaGeoJson(filtered, extent);
+      const merged = this.mergeCountsIntoAreas(cachedGeometries, this.countsFromAreas(cachedGeometries), filter);
+      const geojson = this.areasService.buildAreaGeoJson(merged, extent);
       this.applyGeoJsonToLayer(apiZoomLevel, geojson);
       return;
     }
 
     const cached = this.countsCacheByApiZoom.get(dataZoomLevel);
-    if (cached) {
-      const needed = this.filterCachedAreasBySelection(cachedGeometries, filter);
-      const allCovered = cached.unrestricted || needed.every(a => cached.counts.has(a.fid));
-
-      if (allCovered) {
-        const merged = this.mergeCountsIntoAreas(cachedGeometries, cached.counts, filter);
-        const geojson = this.areasService.buildAreaGeoJson(merged, extent);
-        this.applyGeoJsonToLayer(apiZoomLevel, geojson);
-        return;
-      }
+    if (cached && cached.selectionKey === this.areaSelectionKey(filter)) {
+      const merged = this.mergeCountsIntoAreas(cachedGeometries, cached.counts, filter);
+      const geojson = this.areasService.buildAreaGeoJson(merged, extent);
+      this.applyGeoJsonToLayer(apiZoomLevel, geojson);
+      return;
     }
 
     this.applyGeoJsonToLayer(apiZoomLevel, '{"type":"FeatureCollection","features":[]}');
@@ -457,11 +460,10 @@ export class MapComponent implements AfterViewInit, OnDestroy {
       debounceTime(300),
       switchMap(({ requests, extent }) => {
         const filter = this.locationFilter();
-        const hasAreaSelection = !!(filter.countyIds?.length || filter.municipalityIds?.length || filter.oceanAreaIds?.length);
 
         // Hent antall for alle forespurte zoomnivåer sekvensielt
         const fetches = requests.map(({ dataZoomLevel, apiZoomLevel }) =>
-          this.fetchCountsForZoomLevel(dataZoomLevel, apiZoomLevel, extent, filter, hasAreaSelection),
+          this.fetchCountsForZoomLevel(dataZoomLevel, apiZoomLevel, extent, filter),
         );
 
         return rxConcat(...fetches);
@@ -475,9 +477,9 @@ export class MapComponent implements AfterViewInit, OnDestroy {
     apiZoomLevel: number,
     extent: [number, number, number, number],
     filter: LocationSearchFilter,
-    hasAreaSelection: boolean,
   ): Observable<void> {
     const cachedGeometries = this.geometryCacheByApiZoom.get(dataZoomLevel);
+    const selectionKey = this.areaSelectionKey(filter);
 
     if (cachedGeometries) {
       const existingCache = this.countsCacheByApiZoom.get(dataZoomLevel);
@@ -489,10 +491,11 @@ export class MapComponent implements AfterViewInit, OnDestroy {
             this.countsCacheByApiZoom.set(dataZoomLevel, {
               counts: countsMap,
               etag: response.etag,
-              unrestricted: !hasAreaSelection,
+              selectionKey,
             });
-          } else if (response.etag && existingCache) {
-            existingCache.etag = response.etag;
+          } else if (existingCache) {
+            existingCache.selectionKey = selectionKey;
+            if (response.etag) existingCache.etag = response.etag;
           }
           const counts = this.countsCacheByApiZoom.get(dataZoomLevel)?.counts ?? new Map();
           const merged = this.mergeCountsIntoAreas(cachedGeometries, counts, filter);
@@ -514,14 +517,18 @@ export class MapComponent implements AfterViewInit, OnDestroy {
 
     return this.areasService.getAreaMarkers(olZoom, filter).pipe(
       tap(areas => {
-        this.geometryCacheByApiZoom.set(dataZoomLevel, areas);
-        const countsMap = new Map(areas.map(a => [a.fid, a.observationCount ?? 0]));
+        // Geometri-cachen tømmes aldri, så den må kun fylles med et komplett, ufiltrert sett
+        if (selectionKey === this.EMPTY_SELECTION_KEY && !this.hasActiveAttributeFilters()) {
+          this.geometryCacheByApiZoom.set(dataZoomLevel, this.withCrossLevelAreas(dataZoomLevel, areas));
+        }
+        const countsMap = this.countsFromAreas(areas);
         this.countsCacheByApiZoom.set(dataZoomLevel, {
           counts: countsMap,
           etag: null,
-          unrestricted: !hasAreaSelection,
+          selectionKey,
         });
-        const geojson = this.areasService.buildAreaGeoJson(areas, extent);
+        const merged = this.mergeCountsIntoAreas(areas, countsMap, filter);
+        const geojson = this.areasService.buildAreaGeoJson(merged, extent);
         this.applyGeoJsonToLayer(apiZoomLevel, geojson);
       }),
       rxMap(() => undefined as void),
@@ -568,23 +575,13 @@ export class MapComponent implements AfterViewInit, OnDestroy {
   private prefetchAreaGeometries(): void {
     this.areasService.getAreaMarkers(ZoomConfig.DEFAULT_ZOOM_LEVEL).pipe(
       tap(areas => {
-        this.geometryCacheByApiZoom.set(ApiZoomLevel.Counties, areas);
-        this.countsCacheByApiZoom.set(ApiZoomLevel.Counties, {
-          counts: new Map(areas.map(a => [a.fid, a.observationCount ?? 0])),
-          etag: null,
-          unrestricted: true,
-        });
+        this.seedCountsFromGeometries(ApiZoomLevel.Counties, areas);
         this.rebuildAllLayers();
       }),
       switchMap(() =>
         this.areasService.getAreaMarkers(ZoomConfig.ZOOM_COUNTIES_THRESHOLD).pipe(
           tap(areas => {
-            this.geometryCacheByApiZoom.set(ApiZoomLevel.Municipalities, areas);
-            this.countsCacheByApiZoom.set(ApiZoomLevel.Municipalities, {
-              counts: new Map(areas.map(a => [a.fid, a.observationCount ?? 0])),
-              etag: null,
-              unrestricted: true,
-            });
+            this.seedCountsFromGeometries(ApiZoomLevel.Municipalities, areas);
             this.rebuildAllLayers();
           }),
         ),
@@ -597,7 +594,53 @@ export class MapComponent implements AfterViewInit, OnDestroy {
     ).subscribe();
   }
 
+  /**
+   * Lagrer prefetchede geometrier, og antallene som følger med dem.
+   * Antallene fra prefetch er ufiltrerte, så de brukes kun når ingen attributtfiltre
+   * er aktive i det svaret kommer inn — ellers hentes riktige antall via fetchCounts$.
+   */
+  private seedCountsFromGeometries(apiZoomLevel: number, areas: AreaMarkerDto[]): void {
+    const all = this.withCrossLevelAreas(apiZoomLevel, areas);
+    this.geometryCacheByApiZoom.set(apiZoomLevel, all);
+
+    if (this.hasActiveAttributeFilters()) return;
+
+    this.countsCacheByApiZoom.set(apiZoomLevel, {
+      counts: this.countsFromAreas(all),
+      etag: null,
+      selectionKey: this.EMPTY_SELECTION_KEY,
+    });
+  }
+
+  /**
+   * Havområder og Svalbard/Bjørnøya/Jan Mayen leveres kun med zoomnivå 1, men hører ikke
+   * til et bestemt zoomnivå og må derfor være tilgjengelige i begge områdelag.
+   */
+  private withCrossLevelAreas(apiZoomLevel: number, areas: AreaMarkerDto[]): AreaMarkerDto[] {
+    if (apiZoomLevel === ApiZoomLevel.Counties) return areas;
+
+    const existingFids = new Set(areas.map(a => a.fid));
+    const crossLevel = (this.geometryCacheByApiZoom.get(ApiZoomLevel.Counties) ?? [])
+      .filter(a => CROSS_LEVEL_AREA_TYPES.has(a.areaTypeId) && !existingFids.has(a.fid));
+
+    return crossLevel.length ? [...areas, ...crossLevel] : areas;
+  }
+
   // ─── Helpers ───────────────────────────────────────────────────────
+
+  private readonly EMPTY_SELECTION_KEY = JSON.stringify([[], [], []]);
+
+  /**
+   * Nøkkel som identifiserer hvilket områdevalg et sett med antall gjelder for.
+   * Brukes til å avgjøre om cachede antall fortsatt er gyldige.
+   */
+  private areaSelectionKey(filter: LocationSearchFilter): string {
+    return JSON.stringify([
+      [...(filter.countyIds ?? [])].sort(),
+      [...(filter.municipalityIds ?? [])].sort(),
+      [...(filter.oceanAreaIds ?? [])].sort(),
+    ]);
+  }
 
   private filterCachedAreasBySelection(areas: AreaMarkerDto[], filter: LocationSearchFilter): AreaMarkerDto[] {
     const countyFids = new Set(filter.countyIds ?? []);
@@ -616,14 +659,29 @@ export class MapComponent implements AfterViewInit, OnDestroy {
     );
   }
 
+  /**
+   * Slår sammen geometrier og antall, og avgjør hvilke områder som skal tegnes.
+   *
+   * Regel: et område vises når det har treff, eller når det er eksplisitt valgt av brukeren.
+   * Valgte områder uten treff vises med "0" slik at brukeren ser at valget ga null resultater.
+   */
   private mergeCountsIntoAreas(areas: AreaMarkerDto[], counts: Map<string, number>, filter: LocationSearchFilter): AreaMarkerDto[] {
-    const filtered = this.filterCachedAreasBySelection(areas, filter);
-    const hasAreaSelection = !!(filter.countyIds?.length || filter.municipalityIds?.length || filter.oceanAreaIds?.length);
-    const merged = filtered.map(a => ({
-      ...a,
-      observationCount: counts.get(a.fid) ?? 0,
-    }));
-    return hasAreaSelection ? merged : merged.filter(a => (a.observationCount ?? 0) > 0);
+    const selectedFids = new Set([
+      ...(filter.countyIds ?? []),
+      ...(filter.municipalityIds ?? []),
+      ...(filter.oceanAreaIds ?? []),
+    ]);
+
+    return this.filterCachedAreasBySelection(areas, filter)
+      .map(a => ({ ...a, observationCount: counts.get(a.fid) ?? 0 }))
+      .filter(a => (a.observationCount ?? 0) > 0 || selectedFids.has(a.fid));
+  }
+
+  /**
+   * Bruker de forhåndsberegnede antallene som følger med geometriene.
+   */
+  private countsFromAreas(areas: AreaMarkerDto[]): Map<string, number> {
+    return new Map(areas.map(a => [a.fid, a.observationCount ?? 0]));
   }
 
   private updateSelectedAreaOverlays(): void {

--- a/Artskart3.WebApp/src/app/shared/components/map.component/map.component.ts
+++ b/Artskart3.WebApp/src/app/shared/components/map.component/map.component.ts
@@ -17,8 +17,8 @@ import {
   effect,
 } from '@angular/core';
 import { LoggingService } from '@shared/logging.service';
-import { Subject, EMPTY, merge } from 'rxjs';
-import { catchError, debounceTime, switchMap, takeUntil, tap } from 'rxjs/operators';
+import { Observable, Subject, EMPTY, merge, concat as rxConcat } from 'rxjs';
+import { catchError, debounceTime, map as rxMap, switchMap, takeUntil, tap } from 'rxjs/operators';
 import { AreasService, LocationSearchFilter } from '@core/services/areas/areas.service';
 import { AreaMarkerDto } from '@shared/models/area/area-marker.model';
 import { ZoomConfig } from '@shared/helpers/zoom/zoom-config';
@@ -72,7 +72,7 @@ export class MapComponent implements AfterViewInit, OnDestroy {
 
   private destroy$ = new Subject<void>();
   private cameraChanged$ = new Subject<void>();
-  private fetchCounts$ = new Subject<{ dataZoomLevel: number; apiZoomLevel: number; extent: [number, number, number, number] }>();
+  private fetchCounts$ = new Subject<{ requests: { dataZoomLevel: number; apiZoomLevel: number }[]; extent: [number, number, number, number] }>();
 
   private readonly areasService = inject(AreasService);
   private readonly sharedMapService = inject(SharedMapService);
@@ -278,6 +278,7 @@ export class MapComponent implements AfterViewInit, OnDestroy {
     this.map.activateHoverInfo();
     this.setupAreaMarkerLayers();
     this.setupCountsFetchPipeline();
+    this.setupLocationsFetchPipeline();
     this.setupCameraChangePipeline();
     this.prefetchAreaGeometries();
     this.rebuildAllLayers();
@@ -385,18 +386,31 @@ export class MapComponent implements AfterViewInit, OnDestroy {
       return;
     }
 
-    // Oppdater begge områdelag
-    this.rebuildAreaLayer(ApiZoomLevel.Counties, filter, extent);
-    this.rebuildAreaLayer(ApiZoomLevel.Municipalities, filter, extent);
+    // Oppdater begge områdelag — synkront fra cache der mulig
+    const pendingFetches: { dataZoomLevel: number; apiZoomLevel: number }[] = [];
+    this.rebuildAreaLayer(ApiZoomLevel.Counties, filter, extent, pendingFetches);
+    this.rebuildAreaLayer(ApiZoomLevel.Municipalities, filter, extent, pendingFetches);
+
+    if (pendingFetches.length > 0) {
+      // Prioriter synlig lag først, hent det andre i bakgrunnen etterpå
+      const currentLayer = apiZoomLevel === ApiZoomLevel.Municipalities
+        ? ApiZoomLevel.Municipalities : ApiZoomLevel.Counties;
+      const sorted = [
+        ...pendingFetches.filter(f => f.apiZoomLevel === currentLayer),
+        ...pendingFetches.filter(f => f.apiZoomLevel !== currentLayer),
+      ];
+      this.fetchCounts$.next({ requests: sorted, extent });
+    }
   }
 
   /**
-   * Bygger et enkelt områdelag fra cache, eller trigger async fetch for antall.
+   * Bygger et enkelt områdelag fra cache, eller legger til i pendingFetches.
    */
   private rebuildAreaLayer(
     apiZoomLevel: number,
     filter: LocationSearchFilter,
     extent: [number, number, number, number],
+    pendingFetches: { dataZoomLevel: number; apiZoomLevel: number }[],
   ): void {
     const dataZoomLevel = apiZoomLevel === ApiZoomLevel.Counties && filter.municipalityIds?.length
       ? ApiZoomLevel.Municipalities
@@ -404,12 +418,10 @@ export class MapComponent implements AfterViewInit, OnDestroy {
     const cachedGeometries = this.geometryCacheByApiZoom.get(dataZoomLevel);
 
     if (!cachedGeometries) {
-      // Geometrier ikke lastet ennå (prefetch pågår) — vis tomt lag
       this.applyGeoJsonToLayer(apiZoomLevel, '{"type":"FeatureCollection","features":[]}');
       return;
     }
 
-    // Ingen attributtfiltre — ufiltrerte antall fra geometri-cachen er korrekte
     if (!this.hasActiveAttributeFilters()) {
       const filtered = this.filterCachedAreasBySelection(cachedGeometries, filter);
       const geojson = this.areasService.buildAreaGeoJson(filtered, extent);
@@ -417,7 +429,6 @@ export class MapComponent implements AfterViewInit, OnDestroy {
       return;
     }
 
-    // Attributtfiltre aktive — sjekk om cachede antall dekker behovet
     const cached = this.countsCacheByApiZoom.get(dataZoomLevel);
     if (cached) {
       const needed = this.filterCachedAreasBySelection(cachedGeometries, filter);
@@ -431,9 +442,8 @@ export class MapComponent implements AfterViewInit, OnDestroy {
       }
     }
 
-    // Antall mangler — tøm lag og hent via debounced pipeline
     this.applyGeoJsonToLayer(apiZoomLevel, '{"type":"FeatureCollection","features":[]}');
-    this.fetchCounts$.next({ dataZoomLevel, apiZoomLevel, extent });
+    pendingFetches.push({ dataZoomLevel, apiZoomLevel });
   }
 
   // ─── Async pipelines ───────────────────────────────────────────────
@@ -445,94 +455,102 @@ export class MapComponent implements AfterViewInit, OnDestroy {
   private setupCountsFetchPipeline(): void {
     this.fetchCounts$.pipe(
       debounceTime(300),
-      switchMap(({ dataZoomLevel, apiZoomLevel, extent }) => {
-        const cachedGeometries = this.geometryCacheByApiZoom.get(dataZoomLevel);
-
-        if (cachedGeometries) {
-          const filter = this.locationFilter();
-          const hasAreaSelection = !!(filter.countyIds?.length || filter.municipalityIds?.length || filter.oceanAreaIds?.length);
-          const existingCache = this.countsCacheByApiZoom.get(dataZoomLevel);
-
-          return this.areasService.getAreaCounts(dataZoomLevel, filter, existingCache?.etag ?? undefined).pipe(
-            tap(response => {
-              if (!response.notModified && response.counts) {
-                const countsMap = new Map(response.counts.map(c => [c.fid, c.observationCount]));
-                this.countsCacheByApiZoom.set(dataZoomLevel, {
-                  counts: countsMap,
-                  etag: response.etag,
-                  unrestricted: !hasAreaSelection,
-                });
-              } else if (response.etag && existingCache) {
-                existingCache.etag = response.etag;
-              }
-              const counts = this.countsCacheByApiZoom.get(dataZoomLevel)?.counts ?? new Map();
-              const merged = this.mergeCountsIntoAreas(cachedGeometries, counts, filter);
-              const geojson = this.areasService.buildAreaGeoJson(merged, extent);
-              this.applyGeoJsonToLayer(apiZoomLevel, geojson);
-            }),
-            catchError((err: unknown) => {
-              this.logger.error(`Failed to load area counts for zoom level ${dataZoomLevel}:`, 'MapComponent', err);
-              return EMPTY;
-            }),
-          );
-        }
-
-        // Fallback: geometrier ikke i cache — hent alt
+      switchMap(({ requests, extent }) => {
         const filter = this.locationFilter();
-<<<<<<< HEAD
-        return merge(
-          this.areasService.getLocationsAsGeoJsonString(extent, filter).pipe(
-            tap(locations => this.applyGeoJsonToLayer(apiZoomLevel, locations)),
-            catchError((err: unknown) => {
-              this.logger.error('Failed to load location points:', 'MapComponent', err);
-              return EMPTY;
-            })
-          ),
-          this.areasService.getLocationPolygons(extent, filter).pipe(
-            tap(polygons => this.map.updateGeoJSONLayer(this.LOCATION_POLYGONS_LAYER_ID, polygons, { mode: 'replace' })),
-            catchError((err: unknown) => {
-              this.logger.error('Failed to load location polygons:', 'MapComponent', err);
-              return EMPTY;
-            })
-          )
-=======
         const hasAreaSelection = !!(filter.countyIds?.length || filter.municipalityIds?.length || filter.oceanAreaIds?.length);
-        const olZoom = dataZoomLevel === ApiZoomLevel.Municipalities
-          ? ZoomConfig.ZOOM_COUNTIES_THRESHOLD
-          : ZoomConfig.DEFAULT_ZOOM_LEVEL;
 
-        return this.areasService.getAreaMarkers(olZoom, filter).pipe(
-          tap(areas => {
-            this.geometryCacheByApiZoom.set(dataZoomLevel, areas);
-            const countsMap = new Map(areas.map(a => [a.fid, a.observationCount ?? 0]));
-            this.countsCacheByApiZoom.set(dataZoomLevel, {
-              counts: countsMap,
-              etag: null,
-              unrestricted: !hasAreaSelection,
-            });
-            const geojson = this.areasService.buildAreaGeoJson(areas, extent);
-            this.applyGeoJsonToLayer(apiZoomLevel, geojson);
-          }),
-          catchError((err: unknown) => {
-            this.logger.error(`Failed to load area markers for zoom level ${dataZoomLevel}:`, 'MapComponent', err);
-            return EMPTY;
-          }),
->>>>>>> aeb7971 (nye områdeinndeling og cache av data)
+        // Hent antall for alle forespurte zoomnivåer sekvensielt
+        const fetches = requests.map(({ dataZoomLevel, apiZoomLevel }) =>
+          this.fetchCountsForZoomLevel(dataZoomLevel, apiZoomLevel, extent, filter, hasAreaSelection),
         );
+
+        return rxConcat(...fetches);
       }),
       takeUntil(this.destroy$),
     ).subscribe();
+  }
 
-    // Separat pipeline for lokasjoner
+  private fetchCountsForZoomLevel(
+    dataZoomLevel: number,
+    apiZoomLevel: number,
+    extent: [number, number, number, number],
+    filter: LocationSearchFilter,
+    hasAreaSelection: boolean,
+  ): Observable<void> {
+    const cachedGeometries = this.geometryCacheByApiZoom.get(dataZoomLevel);
+
+    if (cachedGeometries) {
+      const existingCache = this.countsCacheByApiZoom.get(dataZoomLevel);
+
+      return this.areasService.getAreaCounts(dataZoomLevel, filter, existingCache?.etag ?? undefined).pipe(
+        tap(response => {
+          if (!response.notModified && response.counts) {
+            const countsMap = new Map(response.counts.map(c => [c.fid, c.observationCount]));
+            this.countsCacheByApiZoom.set(dataZoomLevel, {
+              counts: countsMap,
+              etag: response.etag,
+              unrestricted: !hasAreaSelection,
+            });
+          } else if (response.etag && existingCache) {
+            existingCache.etag = response.etag;
+          }
+          const counts = this.countsCacheByApiZoom.get(dataZoomLevel)?.counts ?? new Map();
+          const merged = this.mergeCountsIntoAreas(cachedGeometries, counts, filter);
+          const geojson = this.areasService.buildAreaGeoJson(merged, extent);
+          this.applyGeoJsonToLayer(apiZoomLevel, geojson);
+        }),
+        rxMap(() => undefined as void),
+        catchError((err: unknown) => {
+          this.logger.error(`Failed to load area counts for zoom level ${dataZoomLevel}:`, 'MapComponent', err);
+          return EMPTY;
+        }),
+      );
+    }
+
+    // Fallback: geometrier ikke i cache — hent alt
+    const olZoom = dataZoomLevel === ApiZoomLevel.Municipalities
+      ? ZoomConfig.ZOOM_COUNTIES_THRESHOLD
+      : ZoomConfig.DEFAULT_ZOOM_LEVEL;
+
+    return this.areasService.getAreaMarkers(olZoom, filter).pipe(
+      tap(areas => {
+        this.geometryCacheByApiZoom.set(dataZoomLevel, areas);
+        const countsMap = new Map(areas.map(a => [a.fid, a.observationCount ?? 0]));
+        this.countsCacheByApiZoom.set(dataZoomLevel, {
+          counts: countsMap,
+          etag: null,
+          unrestricted: !hasAreaSelection,
+        });
+        const geojson = this.areasService.buildAreaGeoJson(areas, extent);
+        this.applyGeoJsonToLayer(apiZoomLevel, geojson);
+      }),
+      rxMap(() => undefined as void),
+      catchError((err: unknown) => {
+        this.logger.error(`Failed to load area markers for zoom level ${dataZoomLevel}:`, 'MapComponent', err);
+        return EMPTY;
+      }),
+    );
+  }
+
+  private setupLocationsFetchPipeline(): void {
     this.locationsFetch$.pipe(
       debounceTime(300),
       switchMap(({ extent, filter }) =>
-        this.areasService.getLocationsAsGeoJsonString(extent, filter).pipe(
-          tap(geojson => this.applyGeoJsonToLayer(ApiZoomLevel.LocationPoints, geojson)),
-          catchError((err: unknown) => {
-            this.logger.error('Failed to load location points:', 'MapComponent', err);
-            return EMPTY;
-          }),
+        merge(
+          this.areasService.getLocationsAsGeoJsonString(extent, filter).pipe(
+            tap(geojson => this.applyGeoJsonToLayer(ApiZoomLevel.LocationPoints, geojson)),
+            catchError((err: unknown) => {
+              this.logger.error('Failed to load location points:', 'MapComponent', err);
+              return EMPTY;
+            }),
+          ),
+          this.areasService.getLocationPolygons(extent, filter).pipe(
+            tap(geojson => this.map.updateGeoJSONLayer(this.LOCATION_POLYGONS_LAYER_ID, geojson, { mode: 'replace' })),
+            catchError((err: unknown) => {
+              this.logger.error('Failed to load location polygons:', 'MapComponent', err);
+              return EMPTY;
+            }),
+          ),
         ),
       ),
       takeUntil(this.destroy$),

--- a/Artskart3.WebApp/src/app/shared/components/map.component/map.component.ts
+++ b/Artskart3.WebApp/src/app/shared/components/map.component/map.component.ts
@@ -51,16 +51,28 @@ export class MapComponent implements AfterViewInit, OnDestroy {
   private readonly MUNICIPALITIES_LAYER_ID = 'area-markers-municipalities';
   private readonly LOCATIONS_LAYER_ID = 'area-markers-locations';
   private readonly LOCATION_POLYGONS_LAYER_ID = 'location-polygons';
+  private readonly SELECTED_AREAS_OVERLAY_ID = 'area-overlay-selected';
 
   public map!: NbicMapComponent;
   private zoomControl?: ArtskartZoomControl;
   private fullscreenControl?: ArtskartFullscreenControl;
   private geolocationControl?: GeolocationMapControl;
-  private areaDataCacheByApiZoom = new Map<number, AreaMarkerDto[]>();
+
+  // Geometri-cache: persistent for hele sesjonen, tømmes aldri ved filterendring
+  private geometryCacheByApiZoom = new Map<number, AreaMarkerDto[]>();
+  // Antall-cache: inneholder antall per fid, ETag og om cachen er ufiltrert
+  private countsCacheByApiZoom = new Map<number, {
+    counts: Map<string, number>;
+    etag: string | null;
+    unrestricted: boolean;
+  }>();
   private mapReady = false;
+  // Sporer forrige attributtfilter for å oppdage endringer som krever refetch
+  private lastAttributeFilterJson = '';
 
   private destroy$ = new Subject<void>();
-  private fetchAreaData$ = new Subject<{ apiZoomLevel: number; olZoom: number; extent: [number, number, number, number] }>();
+  private cameraChanged$ = new Subject<void>();
+  private fetchCounts$ = new Subject<{ dataZoomLevel: number; apiZoomLevel: number; extent: [number, number, number, number] }>();
 
   private readonly areasService = inject(AreasService);
   private readonly sharedMapService = inject(SharedMapService);
@@ -69,9 +81,11 @@ export class MapComponent implements AfterViewInit, OnDestroy {
   private readonly areaService = inject(AreaService);
   private readonly translate = inject(TranslateService);
 
-  private readonly locationFilter = computed<LocationSearchFilter>(
+  /**
+   * Observasjonsattributtfiltre som påvirker antall per område.
+   */
+  private readonly attributeFilter = computed(
     () => {
-      const { countyIds, municipalityIds } = this.areaService.resolvedAreaFilter();
       const coordinatePrecisionFrom = this.filterState.coordinatePrecisionFrom();
       const coordinatePrecisionTo = this.filterState.coordinatePrecisionTo();
       const periodFrom = this.filterState.periodFrom();
@@ -90,29 +104,52 @@ export class MapComponent implements AfterViewInit, OnDestroy {
         basisOfRecordIds: this.filterState.selectedBasisOfRecordIds().length ? this.filterState.selectedBasisOfRecordIds() : undefined,
         registrationStatusId: this.filterState.selectedRegistrationStatusId() ?? undefined,
         taxonGroupIds: this.filterState.selectedTaxonGroupIds().length ? this.filterState.selectedTaxonGroupIds() : undefined,
-        countyIds: countyIds.length ? countyIds : undefined,
-        municipalityIds: municipalityIds.length ? municipalityIds : undefined,
-        oceanAreaIds: this.filterState.selectedOceanAreaIds().length ? this.filterState.selectedOceanAreaIds() : undefined,
-        coordinatePrecisionFrom: coordinatePrecisionFrom,
-        coordinatePrecisionTo: coordinatePrecisionTo,
-        periodFrom: periodFrom,
-        periodTo: periodTo,
-        projectName: projectName ? projectName : undefined,
+        coordinatePrecisionFrom,
+        coordinatePrecisionTo,
+        periodFrom,
+        periodTo,
+        projectName: projectName || undefined,
         projectOrganizationId: projectOrganizationId ?? undefined,
-        collectionCode: collectionCode ? collectionCode : undefined,
-        catalogNumber: catalogNumber ? catalogNumber : undefined,
-        withImages: withImages,
+        collectionCode: collectionCode || undefined,
+        catalogNumber: catalogNumber || undefined,
+        withImages,
         periodMonths: periodMonths.length ? periodMonths : undefined,
       };
     },
     { equal: (a, b) => JSON.stringify(a) === JSON.stringify(b) },
   );
 
-  private readonly _refetchOnFilterChange = effect(() => {
+  /**
+   * Komplett filter inkludert områdevalg.
+   */
+  private readonly locationFilter = computed<LocationSearchFilter>(
+    () => {
+      const { countyIds, municipalityIds } = this.areaService.resolvedAreaFilter();
+      const attr = this.attributeFilter();
+      return {
+        ...attr,
+        countyIds: countyIds.length ? countyIds : undefined,
+        municipalityIds: municipalityIds.length ? municipalityIds : undefined,
+        oceanAreaIds: this.filterState.selectedOceanAreaIds().length ? this.filterState.selectedOceanAreaIds() : undefined,
+      };
+    },
+    { equal: (a, b) => JSON.stringify(a) === JSON.stringify(b) },
+  );
+
+  private hasActiveAttributeFilters(): boolean {
+    return Object.values(this.attributeFilter()).some(v =>
+      v != null && (!Array.isArray(v) || v.length > 0),
+    );
+  }
+
+  /**
+   * Eneste effekt som reagerer på filterendringer.
+   * Leser alle filtersignaler og trigget rebuildAllLayers ved endring.
+   */
+  private readonly _onFilterChange = effect(() => {
     this.locationFilter();
     if (this.mapReady) {
-      this.areaDataCacheByApiZoom.clear();
-      this.emitFetchEvent();
+      this.rebuildAllLayers();
     }
   });
 
@@ -240,9 +277,10 @@ export class MapComponent implements AfterViewInit, OnDestroy {
     if (!this.map) return;
     this.map.activateHoverInfo();
     this.setupAreaMarkerLayers();
-    this.setupAreaDataPipeline();
-    this.map.on(MapEvents.CameraChanged, (camera) => this.onCameraChanged(camera.zoom));
-    this.emitFetchEvent();
+    this.setupCountsFetchPipeline();
+    this.setupCameraChangePipeline();
+    this.prefetchAreaGeometries();
+    this.rebuildAllLayers();
   }
 
   private setupAreaMarkerLayers(): void {
@@ -265,6 +303,14 @@ export class MapComponent implements AfterViewInit, OnDestroy {
       zIndexPinned: true,
       minZoom: ZoomConfig.ZOOM_COUNTIES_THRESHOLD,
       maxZoom: ZoomConfig.ZOOM_MUNICIPALITIES_THRESHOLD,
+    });
+
+    this.map.addLayer({
+      id: this.SELECTED_AREAS_OVERLAY_ID,
+      kind: 'vector',
+      source: { type: 'memory' },
+      pickable: false,
+      zIndex: 60,
     });
 
     this.map.addLayer({
@@ -301,47 +347,139 @@ export class MapComponent implements AfterViewInit, OnDestroy {
     });
   }
 
-  private onCameraChanged(zoom: number): void {
-    this.emitFetchEvent(zoom);
+  private setupCameraChangePipeline(): void {
+    this.map.on(MapEvents.CameraChanged, () => this.cameraChanged$.next());
+    this.cameraChanged$.pipe(
+      debounceTime(150),
+      takeUntil(this.destroy$),
+    ).subscribe(() => this.rebuildAllLayers());
   }
 
-  private emitFetchEvent(olZoom?: number): void {
-    const currentZoom = olZoom ?? this.map?.getCamera().zoom ?? ZoomConfig.DEFAULT_ZOOM_LEVEL;
-    const apiZoomLevel = ZoomConfig.getApiZoomLevel(currentZoom);
+  // ─── Unified rebuild ───────────────────────────────────────────────
+
+  /**
+   * Eneste inngangspunkt for å oppdatere kartlag.
+   * Kalles ved filterendring, zoomendring og kamerabevegelse.
+   */
+  private rebuildAllLayers(): void {
+    if (!this.map) return;
+
+    const filter = this.locationFilter();
     const extent = this.map.getExtent() as [number, number, number, number];
-    this.fetchAreaData$.next({ apiZoomLevel, olZoom: currentZoom, extent });
+    const olZoom = this.map.getCamera().zoom ?? ZoomConfig.DEFAULT_ZOOM_LEVEL;
+    const apiZoomLevel = ZoomConfig.getApiZoomLevel(olZoom);
+
+    // Sjekk om attributtfiltre har endret seg siden sist
+    const attrJson = JSON.stringify(this.attributeFilter());
+    if (attrJson !== this.lastAttributeFilterJson) {
+      this.countsCacheByApiZoom.clear();
+      this.lastAttributeFilterJson = attrJson;
+    }
+
+    // Oppdater overlay
+    this.updateSelectedAreaOverlays();
+
+    // Oppdater lokasjoner via debounced pipeline
+    if (apiZoomLevel === ApiZoomLevel.LocationPoints) {
+      this.emitLocationsFetch(extent, filter);
+      return;
+    }
+
+    // Oppdater begge områdelag
+    this.rebuildAreaLayer(ApiZoomLevel.Counties, filter, extent);
+    this.rebuildAreaLayer(ApiZoomLevel.Municipalities, filter, extent);
   }
 
-  private setupAreaDataPipeline(): void {
-    this.fetchAreaData$.pipe(
+  /**
+   * Bygger et enkelt områdelag fra cache, eller trigger async fetch for antall.
+   */
+  private rebuildAreaLayer(
+    apiZoomLevel: number,
+    filter: LocationSearchFilter,
+    extent: [number, number, number, number],
+  ): void {
+    const dataZoomLevel = apiZoomLevel === ApiZoomLevel.Counties && filter.municipalityIds?.length
+      ? ApiZoomLevel.Municipalities
+      : apiZoomLevel;
+    const cachedGeometries = this.geometryCacheByApiZoom.get(dataZoomLevel);
+
+    if (!cachedGeometries) {
+      // Geometrier ikke lastet ennå (prefetch pågår) — vis tomt lag
+      this.applyGeoJsonToLayer(apiZoomLevel, '{"type":"FeatureCollection","features":[]}');
+      return;
+    }
+
+    // Ingen attributtfiltre — ufiltrerte antall fra geometri-cachen er korrekte
+    if (!this.hasActiveAttributeFilters()) {
+      const filtered = this.filterCachedAreasBySelection(cachedGeometries, filter);
+      const geojson = this.areasService.buildAreaGeoJson(filtered, extent);
+      this.applyGeoJsonToLayer(apiZoomLevel, geojson);
+      return;
+    }
+
+    // Attributtfiltre aktive — sjekk om cachede antall dekker behovet
+    const cached = this.countsCacheByApiZoom.get(dataZoomLevel);
+    if (cached) {
+      const needed = this.filterCachedAreasBySelection(cachedGeometries, filter);
+      const allCovered = cached.unrestricted || needed.every(a => cached.counts.has(a.fid));
+
+      if (allCovered) {
+        const merged = this.mergeCountsIntoAreas(cachedGeometries, cached.counts, filter);
+        const geojson = this.areasService.buildAreaGeoJson(merged, extent);
+        this.applyGeoJsonToLayer(apiZoomLevel, geojson);
+        return;
+      }
+    }
+
+    // Antall mangler — tøm lag og hent via debounced pipeline
+    this.applyGeoJsonToLayer(apiZoomLevel, '{"type":"FeatureCollection","features":[]}');
+    this.fetchCounts$.next({ dataZoomLevel, apiZoomLevel, extent });
+  }
+
+  // ─── Async pipelines ───────────────────────────────────────────────
+
+  /**
+   * Debounced pipeline for henting av antall fra backend.
+   * Brukes kun når cache ikke dekker behovet.
+   */
+  private setupCountsFetchPipeline(): void {
+    this.fetchCounts$.pipe(
       debounceTime(300),
-      switchMap(({ apiZoomLevel, olZoom, extent }) => {
-        const isLocationPoints = apiZoomLevel === ApiZoomLevel.LocationPoints;
+      switchMap(({ dataZoomLevel, apiZoomLevel, extent }) => {
+        const cachedGeometries = this.geometryCacheByApiZoom.get(dataZoomLevel);
 
-        // For områdemarkører: bruk cachet data og bygg GeoJSON med gjeldende kartutsnitt
-        if (!isLocationPoints) {
-          const cachedAreas = this.areaDataCacheByApiZoom.get(apiZoomLevel);
-          if (cachedAreas) {
-            const geojson = this.areasService.buildAreaGeoJson(cachedAreas, extent);
-            this.applyGeoJsonToLayer(apiZoomLevel, geojson);
-            return EMPTY;
-          }
-
+        if (cachedGeometries) {
           const filter = this.locationFilter();
-          return this.areasService.getAreaMarkers(olZoom, filter).pipe(
-            tap(areas => {
-              this.areaDataCacheByApiZoom.set(apiZoomLevel, areas);
-              const geojson = this.areasService.buildAreaGeoJson(areas, extent);
+          const hasAreaSelection = !!(filter.countyIds?.length || filter.municipalityIds?.length || filter.oceanAreaIds?.length);
+          const existingCache = this.countsCacheByApiZoom.get(dataZoomLevel);
+
+          return this.areasService.getAreaCounts(dataZoomLevel, filter, existingCache?.etag ?? undefined).pipe(
+            tap(response => {
+              if (!response.notModified && response.counts) {
+                const countsMap = new Map(response.counts.map(c => [c.fid, c.observationCount]));
+                this.countsCacheByApiZoom.set(dataZoomLevel, {
+                  counts: countsMap,
+                  etag: response.etag,
+                  unrestricted: !hasAreaSelection,
+                });
+              } else if (response.etag && existingCache) {
+                existingCache.etag = response.etag;
+              }
+              const counts = this.countsCacheByApiZoom.get(dataZoomLevel)?.counts ?? new Map();
+              const merged = this.mergeCountsIntoAreas(cachedGeometries, counts, filter);
+              const geojson = this.areasService.buildAreaGeoJson(merged, extent);
               this.applyGeoJsonToLayer(apiZoomLevel, geojson);
             }),
             catchError((err: unknown) => {
-              this.logger.error(`Failed to load area markers for API zoom level ${apiZoomLevel}:`, 'MapComponent', err);
+              this.logger.error(`Failed to load area counts for zoom level ${dataZoomLevel}:`, 'MapComponent', err);
               return EMPTY;
-            })
+            }),
           );
         }
 
+        // Fallback: geometrier ikke i cache — hent alt
         const filter = this.locationFilter();
+<<<<<<< HEAD
         return merge(
           this.areasService.getLocationsAsGeoJsonString(extent, filter).pipe(
             tap(locations => this.applyGeoJsonToLayer(apiZoomLevel, locations)),
@@ -357,10 +495,145 @@ export class MapComponent implements AfterViewInit, OnDestroy {
               return EMPTY;
             })
           )
+=======
+        const hasAreaSelection = !!(filter.countyIds?.length || filter.municipalityIds?.length || filter.oceanAreaIds?.length);
+        const olZoom = dataZoomLevel === ApiZoomLevel.Municipalities
+          ? ZoomConfig.ZOOM_COUNTIES_THRESHOLD
+          : ZoomConfig.DEFAULT_ZOOM_LEVEL;
+
+        return this.areasService.getAreaMarkers(olZoom, filter).pipe(
+          tap(areas => {
+            this.geometryCacheByApiZoom.set(dataZoomLevel, areas);
+            const countsMap = new Map(areas.map(a => [a.fid, a.observationCount ?? 0]));
+            this.countsCacheByApiZoom.set(dataZoomLevel, {
+              counts: countsMap,
+              etag: null,
+              unrestricted: !hasAreaSelection,
+            });
+            const geojson = this.areasService.buildAreaGeoJson(areas, extent);
+            this.applyGeoJsonToLayer(apiZoomLevel, geojson);
+          }),
+          catchError((err: unknown) => {
+            this.logger.error(`Failed to load area markers for zoom level ${dataZoomLevel}:`, 'MapComponent', err);
+            return EMPTY;
+          }),
+>>>>>>> aeb7971 (nye områdeinndeling og cache av data)
         );
       }),
       takeUntil(this.destroy$),
     ).subscribe();
+
+    // Separat pipeline for lokasjoner
+    this.locationsFetch$.pipe(
+      debounceTime(300),
+      switchMap(({ extent, filter }) =>
+        this.areasService.getLocationsAsGeoJsonString(extent, filter).pipe(
+          tap(geojson => this.applyGeoJsonToLayer(ApiZoomLevel.LocationPoints, geojson)),
+          catchError((err: unknown) => {
+            this.logger.error('Failed to load location points:', 'MapComponent', err);
+            return EMPTY;
+          }),
+        ),
+      ),
+      takeUntil(this.destroy$),
+    ).subscribe();
+  }
+
+  private locationsFetch$ = new Subject<{ extent: [number, number, number, number]; filter: LocationSearchFilter }>();
+
+  private emitLocationsFetch(extent: [number, number, number, number], filter: LocationSearchFilter): void {
+    this.locationsFetch$.next({ extent, filter });
+  }
+
+  // ─── Prefetch ──────────────────────────────────────────────────────
+
+  private prefetchAreaGeometries(): void {
+    this.areasService.getAreaMarkers(ZoomConfig.DEFAULT_ZOOM_LEVEL).pipe(
+      tap(areas => {
+        this.geometryCacheByApiZoom.set(ApiZoomLevel.Counties, areas);
+        this.countsCacheByApiZoom.set(ApiZoomLevel.Counties, {
+          counts: new Map(areas.map(a => [a.fid, a.observationCount ?? 0])),
+          etag: null,
+          unrestricted: true,
+        });
+        this.rebuildAllLayers();
+      }),
+      switchMap(() =>
+        this.areasService.getAreaMarkers(ZoomConfig.ZOOM_COUNTIES_THRESHOLD).pipe(
+          tap(areas => {
+            this.geometryCacheByApiZoom.set(ApiZoomLevel.Municipalities, areas);
+            this.countsCacheByApiZoom.set(ApiZoomLevel.Municipalities, {
+              counts: new Map(areas.map(a => [a.fid, a.observationCount ?? 0])),
+              etag: null,
+              unrestricted: true,
+            });
+            this.rebuildAllLayers();
+          }),
+        ),
+      ),
+      catchError((err: unknown) => {
+        this.logger.error('Failed to prefetch area geometries:', 'MapComponent', err);
+        return EMPTY;
+      }),
+      takeUntil(this.destroy$),
+    ).subscribe();
+  }
+
+  // ─── Helpers ───────────────────────────────────────────────────────
+
+  private filterCachedAreasBySelection(areas: AreaMarkerDto[], filter: LocationSearchFilter): AreaMarkerDto[] {
+    const countyFids = new Set(filter.countyIds ?? []);
+    const municipalityFids = new Set(filter.municipalityIds ?? []);
+    const oceanAreaFids = new Set(filter.oceanAreaIds ?? []);
+
+    if (countyFids.size === 0 && municipalityFids.size === 0 && oceanAreaFids.size === 0) {
+      return areas;
+    }
+
+    return areas.filter(a =>
+      countyFids.has(a.fid) ||
+      municipalityFids.has(a.fid) ||
+      oceanAreaFids.has(a.fid) ||
+      (a.parentFid && countyFids.has(a.parentFid)),
+    );
+  }
+
+  private mergeCountsIntoAreas(areas: AreaMarkerDto[], counts: Map<string, number>, filter: LocationSearchFilter): AreaMarkerDto[] {
+    const filtered = this.filterCachedAreasBySelection(areas, filter);
+    const hasAreaSelection = !!(filter.countyIds?.length || filter.municipalityIds?.length || filter.oceanAreaIds?.length);
+    const merged = filtered.map(a => ({
+      ...a,
+      observationCount: counts.get(a.fid) ?? 0,
+    }));
+    return hasAreaSelection ? merged : merged.filter(a => (a.observationCount ?? 0) > 0);
+  }
+
+  private updateSelectedAreaOverlays(): void {
+    if (!this.map) return;
+
+    const { countyIds, municipalityIds } = this.areaService.resolvedAreaFilter();
+    const selectedOceanAreaFids = this.filterState.selectedOceanAreaIds();
+
+    const countyAreas = this.geometryCacheByApiZoom.get(ApiZoomLevel.Counties) ?? [];
+    const municipalityAreas = this.geometryCacheByApiZoom.get(ApiZoomLevel.Municipalities) ?? [];
+
+    const parentCountyFids = municipalityIds.length > 0
+      ? [...new Set(
+          municipalityAreas
+            .filter(a => municipalityIds.includes(a.fid) && a.parentFid)
+            .map(a => a.parentFid),
+        )]
+      : [];
+
+    const countyLevelFids = [...new Set([...countyIds, ...selectedOceanAreaFids, ...parentCountyFids])];
+    const countyFeatures = this.areasService.buildOverlayFeatures(countyAreas, countyLevelFids);
+    const municipalityFeatures = this.areasService.buildOverlayFeatures(municipalityAreas, municipalityIds);
+    const combined = JSON.stringify({
+      type: 'FeatureCollection',
+      features: [...countyFeatures, ...municipalityFeatures],
+    });
+
+    this.map.updateGeoJSONLayer(this.SELECTED_AREAS_OVERLAY_ID, combined, { mode: 'replace' });
   }
 
   private applyGeoJsonToLayer(apiZoomLevel: number, geojson: string): void {
@@ -379,14 +652,6 @@ export class MapComponent implements AfterViewInit, OnDestroy {
     });
   }
 
-  private cleanup(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
-    this.geolocationControl?.dispose();
-    this.areaDataCacheByApiZoom.clear();
-    this.map?.destroy?.();
-  }
-
   onIconClick(iconName: string): void {
     if (!iconName.startsWith(this.MAP_TYPE_PREFIX)) {
       return;
@@ -394,6 +659,15 @@ export class MapComponent implements AfterViewInit, OnDestroy {
     const layerId = iconName.slice(this.MAP_TYPE_PREFIX.length);
     if (!this.map || !layerId) return;
     this.map.setLayerVisibility(layerId, true);
+  }
+
+  private cleanup(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+    this.geolocationControl?.dispose();
+    this.geometryCacheByApiZoom.clear();
+    this.countsCacheByApiZoom.clear();
+    this.map?.destroy?.();
   }
 
   ngOnDestroy(): void {

--- a/Artskart3.WebApp/src/app/shared/components/sidebar/sidebar.component.html
+++ b/Artskart3.WebApp/src/app/shared/components/sidebar/sidebar.component.html
@@ -104,73 +104,23 @@
               </adb-accordion-item>
             }
           </adb-accordion>
-          @if (janMayenGroup(); as janMayen) {
-            <h6 class="area-section-heading">{{ 'sidebar.areaSection.janMayen' | translate }}</h6>
-            <adb-accordion>
-              <adb-accordion-item>
-                <adb-checkbox
-                  slot="heading"
-                  [attr.checked]="isAllInCountySelected(janMayen) ? '' : null"
-                  [attr.indeterminate]="isSomeInCountySelected(janMayen) ? '' : null"
-                  (click)="$event.stopPropagation()"
-                  (change)="onCountyToggle(janMayen)"
-                >
-                  {{ janMayen.county.name }}
-                  @if (janMayen.county.observationCount !== null && janMayen.county.observationCount !== undefined) {
-                    <span slot="counter">{{ janMayen.county.observationCount | formatNumber:translate.currentLang }}</span>
-                  }
-                </adb-checkbox>
-                <div class="category-children">
-                  @for (municipality of janMayen.municipalities; track municipality.fid) {
-                    @if (municipality.fid) {
-                      <adb-checkbox
-                        [attr.checked]="isMunicipalitySelected(municipality.fid) ? '' : null"
-                        (change)="onMunicipalityToggle(municipality.fid)"
-                      >
-                        {{ municipality.name }}
-                        @if (municipality.observationCount !== null && municipality.observationCount !== undefined) {
-                          <span slot="counter">{{ municipality.observationCount | formatNumber:translate.currentLang }}</span>
-                        }
-                      </adb-checkbox>
+          @if (svalbardBjornoyaAndJanMayenAreas(); as sbjmAreas) {
+            @if (sbjmAreas.length > 0) {
+              <h6 class="area-section-heading">{{ 'sidebar.areaSection.svalbardBjørnøyaAndJanMayen' | translate }}</h6>
+              <div class="category-flat">
+                @for (area of sbjmAreas; track area.fid) {
+                  <adb-checkbox
+                    [attr.checked]="isCountySelected(area.fid) ? '' : null"
+                    (change)="onCountyCheckboxToggle(area.fid)"
+                  >
+                    {{ area.name }}
+                    @if (area.observationCount !== null && area.observationCount !== undefined) {
+                      <span slot="counter">{{ area.observationCount | formatNumber:translate.currentLang }}</span>
                     }
-                  }
-                </div>
-              </adb-accordion-item>
-            </adb-accordion>
-          }
-          @if (svalbardGroup(); as svalbard) {
-            <h6 class="area-section-heading">{{ 'sidebar.areaSection.svalbard' | translate }}</h6>
-            <adb-accordion>
-              <adb-accordion-item>
-                <adb-checkbox
-                  slot="heading"
-                  [attr.checked]="isAllInCountySelected(svalbard) ? '' : null"
-                  [attr.indeterminate]="isSomeInCountySelected(svalbard) ? '' : null"
-                  (click)="$event.stopPropagation()"
-                  (change)="onCountyToggle(svalbard)"
-                >
-                  {{ svalbard.county.name }}
-                  @if (svalbard.county.observationCount !== null && svalbard.county.observationCount !== undefined) {
-                    <span slot="counter">{{ svalbard.county.observationCount | formatNumber:translate.currentLang }}</span>
-                  }
-                </adb-checkbox>
-                <div class="category-children">
-                  @for (municipality of svalbard.municipalities; track municipality.fid) {
-                    @if (municipality.fid) {
-                      <adb-checkbox
-                        [attr.checked]="isMunicipalitySelected(municipality.fid) ? '' : null"
-                        (change)="onMunicipalityToggle(municipality.fid)"
-                      >
-                        {{ municipality.name }}
-                        @if (municipality.observationCount !== null && municipality.observationCount !== undefined) {
-                          <span slot="counter">{{ municipality.observationCount | formatNumber:translate.currentLang }}</span>
-                        }
-                      </adb-checkbox>
-                    }
-                  }
-                </div>
-              </adb-accordion-item>
-            </adb-accordion>
+                  </adb-checkbox>
+                }
+              </div>
+            }
           }
           @if (oceanAreaGroup(); as oceanAreas) {
             <h6 class="area-section-heading">{{ 'sidebar.areaSection.oceanAreas' | translate }}</h6>

--- a/Artskart3.WebApp/src/app/shared/components/sidebar/sidebar.component.spec.ts
+++ b/Artskart3.WebApp/src/app/shared/components/sidebar/sidebar.component.spec.ts
@@ -19,7 +19,7 @@ describe('SidebarComponent', () => {
 
   const mockAreaResponse = {
     counties: {
-      fastlandsNorge: [{ id: 1, fid: '03', name: 'Oslo', isCurrent: true }],
+      areas: [{ id: 1, fid: '03', name: 'Oslo', isCurrent: true }],
     },
     municipalities: {
       id: 2,

--- a/Artskart3.WebApp/src/app/shared/components/sidebar/sidebar.component.ts
+++ b/Artskart3.WebApp/src/app/shared/components/sidebar/sidebar.component.ts
@@ -117,8 +117,7 @@ export class SidebarComponent {
   });
   readonly taxonGroups = this.taxonGroupsResource.value;
   readonly countyGroups = this.areaService.countyGroups;
-  readonly janMayenGroup = this.areaService.janMayenGroup;
-  readonly svalbardGroup = this.areaService.svalbardGroup;
+  readonly svalbardBjornoyaAndJanMayenAreas = this.areaService.svalbardBjornoyaAndJanMayenAreas;
   readonly oceanAreaGroup = this.areaService.oceanAreaGroup;
 
   isCategorySelected(id: number): boolean {

--- a/Artskart3.WebApp/src/app/shared/models/area/area-marker.model.ts
+++ b/Artskart3.WebApp/src/app/shared/models/area/area-marker.model.ts
@@ -45,6 +45,18 @@ export interface AreaMarkerFeature {
   };
 }
 
+/**
+ * Speiler Artskart3.Core/Domain/Enums/AreaType.cs
+ */
+export enum AreaTypeId {
+  Municipality = 1,
+  County = 2,
+  RestrictedArea = 3,
+  OceanArea = 4,
+  NorwaysMarineAreas = 5,
+  SvalbardBjørnøyaAndJanMayen = 6,
+}
+
 export const AREA_TYPE_CONFIG: Record<number, {
   id: number;
   name: string;

--- a/Artskart3.WebApp/src/app/shared/models/area/index.ts
+++ b/Artskart3.WebApp/src/app/shared/models/area/index.ts
@@ -5,6 +5,7 @@ export type {
 
 export {
   AREA_TYPE_CONFIG,
+  AreaTypeId,
   getAreaTypeName,
   getAreaTypeColor
 } from './area-marker.model';

--- a/Artskart3.WebApp/src/app/shared/services/area/area.service.spec.ts
+++ b/Artskart3.WebApp/src/app/shared/services/area/area.service.spec.ts
@@ -12,7 +12,7 @@ describe('AreaService', () => {
 
   const mockAreaResponse: AreaResponseDto = {
     counties: {
-      fastlandsNorge: [
+      areas: [
         { id: 1, fid: '03', name: 'Oslo', isCurrent: true, observationCount: 100 },
         { id: 2, fid: '11', name: 'Rogaland', isCurrent: true, observationCount: 200 },
       ],
@@ -94,7 +94,7 @@ describe('AreaService', () => {
   it('should group municipalities correctly when fids are not zero-padded', () => {
     const unpadded: AreaResponseDto = {
       counties: {
-        fastlandsNorge: [
+        areas: [
           { id: 1, fid: '3', name: 'Oslo', isCurrent: true, observationCount: 100 },
           { id: 2, fid: '11', name: 'Rogaland', isCurrent: true, observationCount: 200 },
         ],

--- a/Artskart3.WebApp/src/app/shared/services/area/area.service.ts
+++ b/Artskart3.WebApp/src/app/shared/services/area/area.service.ts
@@ -28,7 +28,7 @@ export class AreaService {
   readonly counties = computed(() => {
     const response = this.areaResponse();
     if (!response?.counties) return [];
-    return (response.counties.fastlandsNorge ?? []).filter(
+    return (response.counties.areas ?? []).filter(
       (a): a is AreaDto & { fid: string } => !!a.fid && !!a.isCurrent,
     );
   });
@@ -54,30 +54,12 @@ export class AreaService {
     }));
   });
 
-  readonly janMayenGroup = computed<CountyGroup | null>(() => {
+  readonly svalbardBjornoyaAndJanMayenAreas = computed<(AreaDto & { fid: string })[]>(() => {
     const response = this.areaResponse();
-    const county = response?.counties?.janMayen;
-    if (!county?.fid || !county.isCurrent) return null;
-    const municipalities = this.municipalities();
-    return {
-      county: county as AreaDto & { fid: string },
-      municipalities: municipalities.filter(
-        (m) => m.fid.padStart(4, '0').substring(0, 2) === county.fid!.padStart(2, '0'),
-      ),
-    };
-  });
-
-  readonly svalbardGroup = computed<CountyGroup | null>(() => {
-    const response = this.areaResponse();
-    const county = response?.counties?.svalbard;
-    if (!county?.fid || !county.isCurrent) return null;
-    const municipalities = this.municipalities();
-    return {
-      county: county as AreaDto & { fid: string },
-      municipalities: municipalities.filter(
-        (m) => m.fid.padStart(4, '0').substring(0, 2) === county.fid!.padStart(2, '0'),
-      ),
-    };
+    if (!response?.svalbardBjørnøyaAndJanMayen) return [];
+    return (response.svalbardBjørnøyaAndJanMayen.areas ?? []).filter(
+      (a): a is AreaDto & { fid: string } => !!a.fid && !!a.isCurrent,
+    );
   });
 
   readonly oceanAreaGroup = computed<CountyGroup | null>(() => {
@@ -117,12 +99,6 @@ export class AreaService {
         ),
       })),
     ];
-
-    const janMayen = this.janMayenGroup();
-    if (janMayen) allGroups.push(janMayen);
-
-    const svalbard = this.svalbardGroup();
-    if (svalbard) allGroups.push(svalbard);
 
     for (const group of allGroups) {
       const groupMunicipalities = group.municipalities;

--- a/Artskart3.WebApp/src/app/shared/types/api.generated.ts
+++ b/Artskart3.WebApp/src/app/shared/types/api.generated.ts
@@ -782,10 +782,11 @@ export interface components {
             centroid?: components["schemas"]["CentroidDto"];
         };
         AreaResponseDto: {
-            counties?: components["schemas"]["CountyDto"];
+            counties?: components["schemas"]["AreaTypeDto"];
             municipalities?: components["schemas"]["AreaTypeDto"];
             restrictedAreas?: components["schemas"]["AreaTypeDto"];
             oceanAreas?: components["schemas"]["AreaTypeDto"];
+            svalbardBjørnøyaAndJanMayen?: components["schemas"]["AreaTypeDto"];
         };
         AreaTypeDto: {
             /** Format: int32 */
@@ -836,11 +837,6 @@ export interface components {
             from?: number | null;
             /** Format: int32 */
             to?: number | null;
-        };
-        CountyDto: {
-            fastlandsNorge?: components["schemas"]["AreaDto"][] | null;
-            janMayen?: components["schemas"]["AreaDto"];
-            svalbard?: components["schemas"]["AreaDto"];
         };
         CsvExportJobDto: {
             /** Format: int32 */

--- a/Artskart3.WebApp/src/app/shared/types/api.types.ts
+++ b/Artskart3.WebApp/src/app/shared/types/api.types.ts
@@ -6,7 +6,6 @@ export type CategoryTypeDto = components['schemas']['CategoryTypeDto'];
 export type CategoryDto = components['schemas']['CategoryDto'];
 export type AreaResponseDto = components['schemas']['AreaResponseDto'];
 export type AreaTypeDto = components['schemas']['AreaTypeDto'];
-export type CountyDto = components['schemas']['CountyDto'];
 export type AreaDto = components['schemas']['AreaDto'];
 export type CoordinatePrecisionDto = components['schemas']['CoordinatePrecisionDto'];
 export type InstitutionDto = components['schemas']['InstitutionDto'];

--- a/Artskart3.WebApp/src/assets/languages/en.json
+++ b/Artskart3.WebApp/src/assets/languages/en.json
@@ -173,8 +173,7 @@
     },
     "areaSection": {
       "fastlandsNorge": "Mainland Norway",
-      "janMayen": "Jan Mayen",
-      "svalbard": "Svalbard",
+      "svalbardBjørnøyaAndJanMayen": "Svalbard, Bjørnøya and Jan Mayen",
       "oceanAreas": "Ocean Areas"
     },
     "taxonGroups": "Taxon Groups",

--- a/Artskart3.WebApp/src/assets/languages/no.json
+++ b/Artskart3.WebApp/src/assets/languages/no.json
@@ -173,8 +173,7 @@
     },
     "areaSection": {
       "fastlandsNorge": "Fastlands-Norge",
-      "janMayen": "Jan Mayen",
-      "svalbard": "Svalbard",
+      "svalbardBjørnøyaAndJanMayen": "Svalbard, Bjørnøya og Jan Mayen",
       "oceanAreas": "Havområder"
     },
     "taxonGroups": "Artsgrupper",

--- a/Scripts/BackfillObservationEntityIndex.sql
+++ b/Scripts/BackfillObservationEntityIndex.sql
@@ -1,0 +1,88 @@
+-- ============================================================================
+-- Backfill av denormaliserte kolonner på ObservationEntityIndex
+-- Kjøres manuelt i SSMS etter at migrasjonen har lagt til kolonnene.
+--
+-- Kolonner som oppdateres:
+--   TaxonGroupId, CategoryId, BasisOfRecordId, CoordinatePrecisionInMeters,
+--   DateTimeCollected, HasMediaFiles, RegistrationStatusId
+--
+-- RegistrationStatusId-verdier:
+--   1 = Funn (standard — ingen Absent/NotRecovered-tagger)
+--   2 = Ikke funnet (TagId = 5 / Absent)
+--   3 = Ikke gjenfunnet (TagId = 6 / NotRecovered)
+--
+-- TaxonGroupId = 0 brukes som markør for uoppdaterte rader.
+-- Skriptet kan trygt kjøres flere ganger — det plukker opp der det slapp.
+-- ============================================================================
+
+SET NOCOUNT ON;
+
+-- RAISERROR med WITH NOWAIT brukes i stedet for PRINT fordi SSMS
+-- bufrer PRINT-output og viser den først når spørringen er ferdig.
+-- RAISERROR med severity 0 og WITH NOWAIT flusher meldingen umiddelbart
+-- til Messages-fanen, slik at fremdrift kan følges i sanntid.
+
+-- Deaktiver indekser under backfill for å unngå vedlikehold per rad
+RAISERROR('Deaktiverer IX_ObservationEntityIndex_EntityLookup...', 0, 1) WITH NOWAIT;
+ALTER INDEX IX_ObservationEntityIndex_EntityLookup ON dbo.ObservationEntityIndex DISABLE;
+RAISERROR('Indeks deaktivert.', 0, 1) WITH NOWAIT;
+RAISERROR('---', 0, 1) WITH NOWAIT;
+
+DECLARE @BatchSize INT = 500000;
+DECLARE @RowsUpdated INT = 1;
+DECLARE @TotalUpdated BIGINT = 0;
+DECLARE @StartTime DATETIME2 = SYSUTCDATETIME();
+DECLARE @Msg NVARCHAR(500);
+
+-- Sjekk hvor mange rader som gjenstår
+DECLARE @Remaining BIGINT;
+SELECT @Remaining = COUNT(*) FROM ObservationEntityIndex WITH (NOLOCK) WHERE TaxonGroupId = 0;
+SET @Msg = CONCAT('Rader som gjenstaar: ', FORMAT(@Remaining, 'N0'));
+RAISERROR(@Msg, 0, 1) WITH NOWAIT;
+SET @Msg = CONCAT('Estimerte batcher: ', CEILING(CAST(@Remaining AS FLOAT) / @BatchSize));
+RAISERROR(@Msg, 0, 1) WITH NOWAIT;
+RAISERROR('---', 0, 1) WITH NOWAIT;
+
+WHILE @RowsUpdated > 0
+BEGIN
+    UPDATE TOP (@BatchSize) idx
+    SET idx.TaxonGroupId = o.TaxonGroupId,
+        idx.CategoryId = o.CategoryId,
+        idx.BasisOfRecordId = o.BasisOfRecordId,
+        idx.CoordinatePrecisionInMeters = o.CoordinatePrecisionInMeters,
+        idx.DateTimeCollected = o.DateTimeCollected,
+        idx.HasMediaFiles = CASE WHEN EXISTS (
+            SELECT 1 FROM dbo.MediaFile mf WHERE mf.Observation_Id = o.Id
+        ) THEN 1 ELSE 0 END,
+        idx.RegistrationStatusId = CASE
+            WHEN EXISTS (SELECT 1 FROM dbo.ObservationTags ot WHERE ot.ObservationId = o.Id AND ot.TagId = 6) THEN 3
+            WHEN EXISTS (SELECT 1 FROM dbo.ObservationTags ot WHERE ot.ObservationId = o.Id AND ot.TagId = 5) THEN 2
+            ELSE 1
+        END
+    FROM dbo.ObservationEntityIndex idx
+    INNER JOIN dbo.Observation o ON o.Id = idx.ObservationId
+    WHERE idx.TaxonGroupId = 0;
+
+    SET @RowsUpdated = @@ROWCOUNT;
+    SET @TotalUpdated = @TotalUpdated + @RowsUpdated;
+
+    IF @RowsUpdated > 0
+    BEGIN
+        SET @Msg = CONCAT(
+            FORMAT(SYSUTCDATETIME(), 'HH:mm:ss'), ' | ',
+            'Batch ferdig: ', FORMAT(@RowsUpdated, 'N0'), ' rader | ',
+            'Totalt: ', FORMAT(@TotalUpdated, 'N0'), ' rader | ',
+            'Tid: ', DATEDIFF(SECOND, @StartTime, SYSUTCDATETIME()), 's'
+        );
+        RAISERROR(@Msg, 0, 1) WITH NOWAIT;
+    END
+END
+
+RAISERROR('---', 0, 1) WITH NOWAIT;
+SET @Msg = CONCAT('Backfill ferdig! Totalt oppdatert: ', FORMAT(@TotalUpdated, 'N0'), ' rader paa ', DATEDIFF(SECOND, @StartTime, SYSUTCDATETIME()), ' sekunder.');
+RAISERROR(@Msg, 0, 1) WITH NOWAIT;
+
+-- Gjenoppbygg indeks
+RAISERROR('Gjenoppbygger IX_ObservationEntityIndex_EntityLookup...', 0, 1) WITH NOWAIT;
+ALTER INDEX IX_ObservationEntityIndex_EntityLookup ON dbo.ObservationEntityIndex REBUILD;
+RAISERROR('Indeks gjenoppbygget!', 0, 1) WITH NOWAIT;


### PR DESCRIPTION
Lagt til ny områdeinndeling for svalbard og jan mayen. For at dette skulle virke som beskrevet kom det en del andre endringer på kjøpet, blandt annet et nytt lag som skal vise områder valgt i filter uansett zoomnivå. + caching av data for å slippe mange rundturer ned i api/database. Vi kan velge å ta ut noe av endringene som er gjort for å gjøre pr mindre, så det er noe å ha i bakholdet.

Vi må kjøre en del script for å oppdatere data i alle miljøene med nye områdeinndeling når vi deployer ut til miljøene, beskrivelse kommer her:
Først må vi slette alle area og areatypes som ligger i databasen og legge inn de nye area kristian har oppdatert. Filen for å legge inn nye ligger i teams under general/shared/nye artskart og heter AreaAndAreaTypes17.08.2026.sql.

I tillegg så må vi kjøre disse scriptene for å oppdatere tellingene for de nye area vi har lagt til, noen av dem tar ganske lang tid:

1. Oppdater LocationAreas
```
-- Fjern eksisterende koblinger for gjeldende områder
  BEGIN TRANSACTION;

  DELETE la FROM LocationAreas la
  INNER JOIN Area a ON la.AreaId = a.Id
  WHERE a.IsCurrent = 1;

  -- Sett inn nye koblinger basert på spatial intersect
  INSERT INTO LocationAreas (LocationId, AreaId)
  SELECT DISTINCT l.Id, a.Id
  FROM Location l
  INNER JOIN Area a ON a.IsCurrent = 1 AND a.WktPolygon IS NOT NULL
  WHERE l.Geometry IS NOT NULL
    AND l.Geometry.STIntersects(a.WktPolygon) = 1;

  -- Verifiser antall
  SELECT a.AreaTypeId, COUNT(*) AS Koblinger
  FROM LocationAreas la
  INNER JOIN Area a ON la.AreaId = a.Id
  WHERE a.IsCurrent = 1
  GROUP BY a.AreaTypeId;

  COMMIT;
```

2. Bygg opp obervationEntityIndex på ny
```
BEGIN TRANSACTION;

  -- Fjern eksisterende område-indeksering (behold institusjoner = 101)
  DELETE FROM ObservationEntityIndex
  WHERE EntityTypeId IN (1, 2, 3, 4, 6);

  -- Sett inn på nytt fra LocationAreas
  INSERT INTO ObservationEntityIndex (ObservationId, EntityTypeId, EntityId)
  SELECT DISTINCT
      o.Id AS ObservationId,
      a.AreaTypeId AS EntityTypeId,
      CAST(REPLACE(
          CASE
              WHEN a.AreaTypeId = 3 THEN REPLACE(a.Fid, 'Naturbase VV', '')
              ELSE REPLACE(a.Fid, '_', '')
          END, ' ', '') AS INT) AS EntityId
  FROM Observation o
  INNER JOIN LocationAreas la ON la.LocationId = o.LocationId
  INNER JOIN Area a ON la.AreaId = a.Id
  WHERE a.IsCurrent = 1
    AND a.AreaTypeId IN (1, 2, 3, 4, 6)
    AND o.LocationId IS NOT NULL
    AND TRY_CAST(REPLACE(
          CASE
              WHEN a.AreaTypeId = 3 THEN REPLACE(a.Fid, 'Naturbase VV', '')
              ELSE REPLACE(a.Fid, '_', '')
          END, ' ', '') AS INT) IS NOT NULL;

  -- Verifiser
  SELECT EntityTypeId, COUNT(DISTINCT EntityId) AS Områder, COUNT(*) AS Rader
  FROM ObservationEntityIndex
  WHERE EntityTypeId IN (1, 2, 3, 4, 6)
  GROUP BY EntityTypeId;

  COMMIT;
```

3. Oppdater area observation count
```
BEGIN TRANSACTION;

  UPDATE a
  SET a.ObservationCount = counts.Antall
  FROM Area a
  INNER JOIN (
      SELECT la.AreaId, COUNT(DISTINCT o.Id) AS Antall
      FROM LocationAreas la
      INNER JOIN Observation o ON o.LocationId = la.LocationId
      GROUP BY la.AreaId
  ) counts ON a.Id = counts.AreaId
  WHERE a.IsCurrent = 1;

  -- Sett 0 for områder uten observasjoner
  UPDATE Area
  SET ObservationCount = 0
  WHERE IsCurrent = 1
    AND Id NOT IN (
      SELECT DISTINCT AreaId FROM LocationAreas
    );

  -- Verifiser
  SELECT a.AreaTypeId, COUNT(*) AS Områder, SUM(a.ObservationCount) AS TotaltAntall
  FROM Area a
  WHERE a.IsCurrent = 1
  GROUP BY a.AreaTypeId;

  COMMIT;
```

4. Kjør backfill av ObservationEntityIndex fra script mappen på roten av repoet.




**Oppsummering av endringer som er gjort:**

Backend — Svalbard/Bjørnøya/Jan Mayen-refaktor
  - Fjernet den gamle CountyDto-strukturen med separate fastlandsNorge, janMayen og svalbard-egenskaper.
  - Lagt til ny SvalbardBjørnøyaAndJanMayen-egenskap på AreaResponseDto som AreaTypeDto med 6 separate områder.
  - LookupService henter nå disse områdene som en egen områdetype i stedet for å bruke fiktive fylkesnummer.

  Backend — Nytt antall-endepunkt med ETag
  - Nytt POST /api/Search/AreaCounts?zoomLevel={1|2}-endepunkt som returnerer kun FID + observasjonsantall (ingen geometri).
  - Støtter ETag-basert caching — returnerer 304 Not Modified når antallene ikke har endret seg.
  - Resultater caches i IMemoryCache med nøkkel basert på SHA256-hash av filteret (5 minutters TTL). Dette betyr at gjentatte forespørsler med samme filter hopper over databasespørringen helt.
  - Ny AreaCountDto og AreaCountsResultDto for lettere respons.

  Backend — Forbedret områdelasting
  - LoadAreasForZoomLevel for ufiltrert zoomnivå 1 inkluderer nå også havområder og Svalbard/Bjørnøya/Jan Mayen-geometrier, slik at frontend kan prefetche alle
  geometrier i én forespørsel.
  - Felles logikk for filtrering og telling er ekstrahert til gjenbrukbare hjelpemetoder (LoadAreasForZoomLevel, FilterAndComputeCounts).
  - GetAreaCountsAsync grupperer nå etter Fid i stedet for Name for å unngå sammenslåing av områder med like navn på tvers av områdetyper.

  Frontend — To-nivå caching og prefetch
  - Geometri-cache (geometryCacheByApiZoom): Persistent for hele sesjonen, tømmes aldri ved filterendring. Fylles ved oppstart.
  - Antall-cache (countsCacheByApiZoom): Inneholder antall per FID, ETag og et unrestricted-flagg. Tømmes kun når attributtfiltre endres.
  - Ved oppstart prefetches fylkegeometrier først, deretter kommunegeometrier i bakgrunnen.
  - Ved filterendringer uten attributtfiltre brukes cachede verdier umiddelbart — ingen API-kall, ingen debounce.

  Frontend — Enhetlig rebuildAllLayers()
  - All oppdatering av kartlag skjer gjennom én funksjon som kalles ved filterendring, kamerabevegelse og fullført prefetch.
  - Oppdaterer alltid begge områdelag (fylker og kommuner) samt overlay-laget, og sikrer at ingen lag viser foreldede data uavhengig av zoom- eller filterrekkefølge.
  - Kamerabevegelser debounces med 150ms for å unngå unødvendig arbeid ved panorering.

  Frontend — Overlay-lag for valgte områder
  - Nytt ikke-klikkbart kartlag (area-overlay-selected) som viser omrissene av valgte områder uavhengig av zoomnivå.
  - Inkluderer valgte fylker, havområder, foreldrefylker til valgte kommuner (for kontekst), og valgte kommuner.
  - Når alle kommuner i et fylke er valgt (via fylke-avkryssning), vises kun fylkeomrisset — ikke alle enkelt-kommuner.

  Frontend — Smartere datavisning ved kommunevalg
  - Når kommuner er valgt og kartet viser fylkesnivå, vises kommunedata i stedet for fylkedata, slik at observasjonstallene plasseres ved kommunens centroid.
  - Områder med 0 observasjoner vises med "0" i sirkelen når et områdefilter er aktivt, men skjules når ingen områdefilter er satt.

  Frontend — Svalbard/Bjørnøya/Jan Mayen i sidebar
  - Erstattet de separate Jan Mayen- og Svalbard-seksjonene i sidepanelet med én flat liste under overskriften "Svalbard, Bjørnøya og Jan Mayen" (norsk) / "Svalbard,
   Bjørnøya and Jan Mayen" (engelsk).
  - Fjernet CountyDto fra genererte typer — bruker nå AreaTypeDto gjennomgående.

  Tester
  - 8 nye backend-enhetstester for GetAreaCountsAsync (service-caching, ETag-oppførsel, 304-respons, validering).
  - Eksisterende tester oppdatert for ny DTO-struktur.
  - Alle 196 backend- og 185 frontend-tester passerer.

  Dokumentasjon
  - README oppdatert med beskrivelse av caching-arkitekturen og kjente forbedringspunkter.
  - Feilmeldinger i SearchRepository harmonisert til norsk.