### PR TITLE
Fix map toolbar hidden in fullscreen

### DIFF
--- a/Artskart3.WebApp/src/app/shared/components/map.component/controls/fullscreen.control.ts
+++ b/Artskart3.WebApp/src/app/shared/components/map.component/controls/fullscreen.control.ts
@@ -14,12 +14,13 @@ export interface FullscreenControlLabels {
 }
 
 export class ArtskartFullscreenControl extends FullScreen {
-  constructor(labels: FullscreenControlLabels) {
+  constructor(labels: FullscreenControlLabels, source?: HTMLElement) {
     super({
       className: 'artskart-fullscreen',
       label: createSvgIcon(FULLSCREEN_SVG),
       labelActive: createSvgIcon(EXIT_FULLSCREEN_SVG),
       tipLabel: labels.tipLabel,
+      source,
     });
     this.updateLabels(labels);
   }

--- a/Artskart3.WebApp/src/app/shared/components/map.component/map.component.ts
+++ b/Artskart3.WebApp/src/app/shared/components/map.component/map.component.ts
@@ -231,9 +231,14 @@ export class MapComponent implements AfterViewInit, OnDestroy {
 
   private adoptFullscreenControl(): void {
     if (!this.map) return;
-    this.fullscreenControl = new ArtskartFullscreenControl({
-      tipLabel: this.translate.instant('mapToolbar.fullscreenAriaLabel'),
-    });
+    // Fullscreen the container wrapping the map so the toolbar (map type selector etc.) stays visible
+    const fullscreenSource = this.mapEl.nativeElement.parentElement ?? undefined;
+    this.fullscreenControl = new ArtskartFullscreenControl(
+      {
+        tipLabel: this.translate.instant('mapToolbar.fullscreenAriaLabel'),
+      },
+      fullscreenSource,
+    );
     this.map.adoptControl(this.fullscreenControl, 'fullscreen');
   }
 

--- a/Artskart3.WebApp/src/test-setup.ts
+++ b/Artskart3.WebApp/src/test-setup.ts
@@ -1,0 +1,8 @@
+// jsdom does not implement ResizeObserver, which OpenLayers' Map constructor requires.
+class ResizeObserverStub {
+  observe(): void {} // eslint-disable-line @typescript-eslint/no-empty-function
+  unobserve(): void {} // eslint-disable-line @typescript-eslint/no-empty-function
+  disconnect(): void {} // eslint-disable-line @typescript-eslint/no-empty-function
+}
+
+globalThis.ResizeObserver = ResizeObserverStub as unknown as typeof ResizeObserver;

--- a/Artskart3.WebApp/vitest.config.ts
+++ b/Artskart3.WebApp/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
+    setupFiles: ['src/test-setup.ts'],
     server: {
       deps: {
         inline: ['@artsdatabanken/nbic-map-component', /^ol\//],


### PR DESCRIPTION
Fix map toolbar hidden in fullscreen by fullscreening the map container

Stub ResizeObserver in test setup so OpenLayers initializes under jsdom