### PR TITLE
Feature/fremvisning av varsler backup

### DIFF
--- a/Artskart3.Infrastructure/Data/JsonDb/README.md
+++ b/Artskart3.Infrastructure/Data/JsonDb/README.md
@@ -1,0 +1,51 @@
+# Notifications (varsler)
+
+`notifications.json` er datakilden for varslene som vises i Artskart-portalen (f.eks. driftsmeldinger, planlagt vedlikehold og annen viktig informasjon til brukerne). Filen redigeres manuelt av en superbruker — det finnes ingen admin-UI for dette per nå.
+
+Endepunktet `GET /api/notifications` leser filen ved hver forespørsel, så en endring blir synlig for klienten umiddelbart etter lagring (ingen restart av API-et er nødvendig).
+
+## Slik legger du til et nytt varsel
+
+Åpne `notifications.json` og legg til et nytt objekt i `notifications`-listen. Husk komma mellom elementene.
+
+```json
+{
+  "type": "Info",
+  "heading": "Kort overskrift for varselet",
+  "description": "Lengre forklarende tekst som vises til brukeren.",
+  "startDateTime": "2026-09-01T08:00:00",
+  "endDateTime": "2026-09-01T16:00:00",
+  "startDisplayDate": "2026-08-28",
+  "endDisplayDate": "2026-09-01",
+  "canClose": true
+}
+```
+
+### Feltbeskrivelse
+
+| Felt | Type | Påkrevd | Beskrivelse |
+|---|---|---|---|
+| `type` | tekst | Ja | Type varsel. Gyldige verdier: `Danger`, `Warning`, `Info`, `Success`, `Neutral`. Se [`AlertType`](../../../Artskart3.Core/Domain/Enums/AlertType.cs). Styrer ikon/farge i frontend. |
+| `heading` | tekst | Ja | Kort overskrift på varselet. |
+| `description` | tekst | Ja | Utfyllende tekst som vises sammen med overskriften. |
+| `startDateTime` | dato/klokkeslett eller `null` | Nei | Når selve hendelsen (f.eks. vedlikeholdet) starter. Kun informativ — styrer ikke om varselet vises. |
+| `endDateTime` | dato/klokkeslett eller `null` | Nei | Når selve hendelsen avsluttes. Kun informativ — styrer ikke om varselet vises. |
+| `startDisplayDate` | dato | Ja | Datoen varselet begynner å vises for brukerne i portalen. |
+| `endDisplayDate` | dato | Ja | Datoen varselet slutter å vises for brukerne i portalen. |
+| `canClose` | `true`/`false` | Ja | Om brukeren kan lukke varselet selv (`true`) eller om det alltid skal vises i perioden (`false`). |
+
+### Datoformat
+
+* Dato og klokkeslett (`startDateTime`, `endDateTime`): ISO 8601, `ÅÅÅÅ-MM-DDTtt:mm:ss`, f.eks. `"2026-09-01T08:00:00"`.
+* Bare dato (`startDisplayDate`, `endDisplayDate`): `ÅÅÅÅ-MM-DD`, f.eks. `"2026-09-01"`.
+* Hvis hendelsen ikke har et bestemt tidspunkt, sett `startDateTime`/`endDateTime` til `null` i stedet for å utelate feltet.
+
+## Fjerne eller avslutte et varsel
+
+Sett `endDisplayDate` til en dato som allerede har passert, eller fjern hele objektet fra listen.
+
+## Validering før lagring
+
+* Filen må være gyldig JSON — pass på komma, anførselstegn og krøllparenteser. Bruk gjerne en JSON-validator (f.eks. i VS Code) før du lagrer.
+* `type` må være stavet nøyaktig som en av de fem gyldige verdiene ovenfor (case-sensitiv).
+* Test gjerne endringen lokalt ved å kalle `GET /api/notifications` mot en lokal API-instans før du oppdaterer produksjonsfilen.

--- a/Artskart3.Infrastructure/Data/JsonDb/notifications.json
+++ b/Artskart3.Infrastructure/Data/JsonDb/notifications.json
@@ -4,20 +4,20 @@
       "type": "Danger",
       "heading": "Tjenesten er midlertidig utilgjengelig",
       "description": "Artskart er for øyeblikket utilgjengelig på grunn av nødvedlikehold. Vi beklager ulempene og jobber med å gjenopprette tjenesten så snart som mulig.",
-      "startDateTime": "2025-06-20T06:00:00",
-      "endDateTime": "2025-06-21T18:00:00",
-      "startDisplayDate": "2025-06-19",
-      "endDisplayDate": "2025-06-21",
+      "startDateTime": "2026-08-20T06:00:00",
+      "endDateTime": "2026-08-31T18:00:00",
+      "startDisplayDate": "2026-08-19",
+      "endDisplayDate": "2026-08-31",
       "canClose": false
     },
     {
       "type": "Warning",
       "heading": "Planlagt vedlikehold",
       "description": "Artskart vil gjennomgå planlagte oppdateringer natt til tirsdag. Noen funksjoner kan være midlertidig utilgjengelige i dette tidsrommet.",
-      "startDateTime": "2025-07-01T22:00:00",
-      "endDateTime": "2025-07-02T04:00:00",
-      "startDisplayDate": "2025-06-28",
-      "endDisplayDate": "2025-07-02",
+      "startDateTime": "2026-08-01T22:00:00",
+      "endDateTime": "2026-08-30T04:00:00",
+      "startDisplayDate": "2026-07-28",
+      "endDisplayDate": "2026-08-30",
       "canClose": true
     },
     {
@@ -26,8 +26,8 @@
       "description": "En ny versjon av Artskart er nå tilgjengelig med forbedret søkefunksjonalitet og feilrettinger. Les mer i endringsloggen.",
       "startDateTime": null,
       "endDateTime": null,
-      "startDisplayDate": "2025-06-15",
-      "endDisplayDate": "2025-06-30",
+      "startDisplayDate": "2026-08-15",
+      "endDisplayDate": "2026-08-30",
       "canClose": true
     }
   ]

--- a/Artskart3.WebApp/src/app/layouts/base-layout/base-layout.component.ts
+++ b/Artskart3.WebApp/src/app/layouts/base-layout/base-layout.component.ts
@@ -1,8 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component, ChangeDetectionStrategy, OnInit, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterOutlet } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { SharedModule } from '../../shared/shared.module';
+import { NotificationsService } from '../../shared/services/notifications/notifications.service';
 
 @Component({
   selector: 'app-base-layout',
@@ -16,4 +17,10 @@ import { SharedModule } from '../../shared/shared.module';
   templateUrl: './base-layout.component.html',
   styleUrls: ['./base-layout.component.css'],
 })
-export class BaseLayoutComponent {}
+export class BaseLayoutComponent implements OnInit {
+  private readonly notificationsService = inject(NotificationsService);
+
+  ngOnInit(): void {
+    this.notificationsService.loadAndShowNotifications();
+  }
+}

--- a/Artskart3.WebApp/src/app/shared/components/alert/alert.component.css
+++ b/Artskart3.WebApp/src/app/shared/components/alert/alert.component.css
@@ -13,3 +13,8 @@
 adb-alert {
   pointer-events: auto;
 }
+
+.alert-date-range {
+  font-size: 0.85rem;
+  opacity: 0.8;
+}

--- a/Artskart3.WebApp/src/app/shared/components/alert/alert.component.html
+++ b/Artskart3.WebApp/src/app/shared/components/alert/alert.component.html
@@ -9,7 +9,7 @@
       {{ alert.message }}
     }
     @if (alert.startDisplayDate || alert.endDisplayDate) {
-      <div class="alert-date-range">{{ alert.startDisplayDate }} &ndash; {{ alert.endDisplayDate }}</div>
+      <div class="alert-date-range">{{ formatDateRange(alert.startDisplayDate, alert.endDisplayDate) }}</div>
     }
     @if (alert.link) {
       <a

--- a/Artskart3.WebApp/src/app/shared/components/alert/alert.component.html
+++ b/Artskart3.WebApp/src/app/shared/components/alert/alert.component.html
@@ -8,6 +8,9 @@
     @if (alert.message) {
       {{ alert.message }}
     }
+    @if (alert.startDisplayDate || alert.endDisplayDate) {
+      <div class="alert-date-range">{{ alert.startDisplayDate }} &ndash; {{ alert.endDisplayDate }}</div>
+    }
     @if (alert.link) {
       <a
         [href]="alert.link.route"

--- a/Artskart3.WebApp/src/app/shared/components/alert/alert.component.ts
+++ b/Artskart3.WebApp/src/app/shared/components/alert/alert.component.ts
@@ -19,4 +19,12 @@ export class AlertComponent {
     this.alertService.dismiss(alertId);
     this.router.navigateByUrl(route);
   }
+
+  protected formatDateRange(startDate?: string, endDate?: string): string {
+    if (startDate && endDate && startDate === endDate) return startDate;
+    if (startDate && endDate) return `${startDate} - ${endDate}`;
+    if (startDate) return `From ${startDate}`;
+    if (endDate) return `Until ${endDate}`;
+    return '';
+  }
 }

--- a/Artskart3.WebApp/src/app/shared/services/alert/alert.service.ts
+++ b/Artskart3.WebApp/src/app/shared/services/alert/alert.service.ts
@@ -12,6 +12,9 @@ export interface AlertOptions {
   closable?: boolean;
   /** Auto-dismiss delay in milliseconds. Defaults to 5000. Set to 0 to disable. */
   autoDismissMs?: number;
+  /** Optional display-only validity period, e.g. from a scheduled notification. */
+  startDisplayDate?: string;
+  endDisplayDate?: string;
   /** Optional link rendered below the message, navigates via Angular Router. */
   link?: AlertLink;
 }
@@ -23,6 +26,8 @@ export interface AlertItem {
   heading?: string;
   closable: boolean;
   autoDismissMs: number;
+  startDisplayDate?: string;
+  endDisplayDate?: string;
   link?: AlertLink;
 }
 
@@ -51,6 +56,8 @@ export class AlertService {
       heading: options?.heading,
       closable: options?.closable ?? true,
       autoDismissMs,
+      startDisplayDate: options?.startDisplayDate,
+      endDisplayDate: options?.endDisplayDate,
       link: options?.link,
     };
 

--- a/Artskart3.WebApp/src/app/shared/services/notifications/notifications.service.ts
+++ b/Artskart3.WebApp/src/app/shared/services/notifications/notifications.service.ts
@@ -2,15 +2,51 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
 import { NotificationModel } from '../../types/api.types';
+import { AlertService, AlertVariant } from '../alert/alert.service';
+
+// Assumed AlertType ordering (0-4) from the backend enum; confirm against the C# AlertType enum and adjust if it differs.
+const ALERT_TYPE_VARIANT: Record<number, AlertVariant> = {
+  0: 'info',
+  1: 'success',
+  2: 'warning',
+  3: 'danger',
+  4: 'danger',
+};
 
 @Injectable({
   providedIn: 'root',
 })
 export class NotificationsService {
   private readonly http = inject(HttpClient);
+  private readonly alertService = inject(AlertService);
   private readonly endpoint = '/api/Notifications';
 
   getNotifications(): Observable<NotificationModel[]> {
     return this.http.get<NotificationModel[]>(this.endpoint);
+  }
+
+  /** Fetches notifications and shows the currently active ones as alerts. */
+  loadAndShowNotifications(): void {
+    this.getNotifications().subscribe((notifications) => {
+      notifications.filter((n) => this.isActive(n)).forEach((n) => this.showNotification(n));
+    });
+  }
+
+  private isActive(notification: NotificationModel): boolean {
+    const now = Date.now();
+    const start = notification.startDateTime ? new Date(notification.startDateTime).getTime() : -Infinity;
+    const end = notification.endDateTime ? new Date(notification.endDateTime).getTime() : Infinity;
+    return now >= start && now <= end;
+  }
+
+  private showNotification(notification: NotificationModel): void {
+    const variant = ALERT_TYPE_VARIANT[notification.type ?? 0] ?? 'info';
+    this.alertService.show(notification.description ?? '', variant, {
+      heading: notification.heading ?? undefined,
+      closable: notification.canClose ?? true,
+      autoDismissMs: 0,
+      startDisplayDate: notification.startDisplayDate ?? undefined,
+      endDisplayDate: notification.endDisplayDate ?? undefined,
+    });
   }
 }

--- a/Artskart3.WebApp/src/app/shared/services/notifications/notifications.service.ts
+++ b/Artskart3.WebApp/src/app/shared/services/notifications/notifications.service.ts
@@ -1,0 +1,16 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import { NotificationModel } from '../../types/api.types';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class NotificationsService {
+  private readonly http = inject(HttpClient);
+  private readonly endpoint = '/api/Notifications';
+
+  getNotifications(): Observable<NotificationModel[]> {
+    return this.http.get<NotificationModel[]>(this.endpoint);
+  }
+}

--- a/Artskart3.WebApp/src/app/shared/services/notifications/notifications.service.ts
+++ b/Artskart3.WebApp/src/app/shared/services/notifications/notifications.service.ts
@@ -4,13 +4,12 @@ import { Observable } from 'rxjs';
 import { NotificationModel } from '../../types/api.types';
 import { AlertService, AlertVariant } from '../alert/alert.service';
 
-// Assumed AlertType ordering (0-4) from the backend enum; confirm against the C# AlertType enum and adjust if it differs.
 const ALERT_TYPE_VARIANT: Record<number, AlertVariant> = {
-  0: 'info',
-  1: 'success',
-  2: 'warning',
-  3: 'danger',
-  4: 'danger',
+  0: 'danger',
+  1: 'warning',
+  2: 'info',
+  3: 'success',
+  4: 'info',
 };
 
 @Injectable({

--- a/Artskart3.WebApp/src/app/shared/types/api.types.ts
+++ b/Artskart3.WebApp/src/app/shared/types/api.types.ts
@@ -16,6 +16,7 @@ export type CsvExportJobDto = components['schemas']['CsvExportJobDto'];
 export type StartExportRequestDto = components['schemas']['StartExportRequestDto'];
 export type ExportSummaryDto = components['schemas']['ExportSummaryDto'];
 export type ObservationSearchFilter = components['schemas']['ObservationSearchFilterDto'];
+export type NotificationModel = components['schemas']['NotificationModel'];
 
 // Export status enum
 export const CSV_EXPORT_STATUS = {

--- a/README.md
+++ b/README.md
@@ -144,6 +144,10 @@ Standariserer navngiving av branches er `feature/navn-på-branch` som for eksemp
 ## Merging av endringer
 For å gjøre endringer i Artskart krever det at det lages en pull request som må godkjennes av en annen utvikler.
 
+## Varsler (notifications)
+Driftsmeldinger og andre varsler som vises i portalen styres via en JSON-fil som redigeres manuelt av en superbruker. Se [`Artskart3.Infrastructure/Data/JsonDb/README.md`](Artskart3.Infrastructure/Data/JsonDb/README.md) for feltbeskrivelse og fremgangsmåte for å legge til nye varsler.
+
+
 ## Begrenset tilgjengelighet til miljøene
 Per juli 2026 er alle miljøene kun tilgjengelig dersom man er tilkoblet Artsdatabankens nettverk direkte eller via VPN.
 


### PR DESCRIPTION
- Sjekk at varsler fungerer og vises som i eksempelet under. Varsler vises per nå frem til den 31/8 som spesifisert i Notifications.json filen.
<img width="1123" height="636" alt="image" src="https://github.com/user-attachments/assets/aac4c2dd-a07b-4b92-b07d-e028ecd4933e" />
- Sjekk at Readme filen som ble lagt til i prosjektet som beskriver hvordan nye varsler legges til er forståelig.